### PR TITLE
fix(sms senders): provide a reason when adding selected senders.

### DIFF
--- a/client/app/telecom/sms/senders/add/telecom-sms-senders-add.controller.js
+++ b/client/app/telecom/sms/senders/add/telecom-sms-senders-add.controller.js
@@ -20,14 +20,10 @@ angular.module("managerApp").controller("TelecomSmsSendersAddCtrl", function ($q
     }
 
     self.getSelection = function () {
-        return _.filter(
-            _.union(
-                self.senders.availableForValidation.nichandle,
-                self.senders.availableForValidation.domains
-            ), function (sender) {
-            return sender && self.senders.availableForValidation.selected && self.senders.availableForValidation.selected[sender.sender];
-        }
-        );
+        var allSelectedSenders = _.union(self.senders.availableForValidation.nichandle, self.senders.availableForValidation.domains);
+        return _.filter(allSelectedSenders, function (sender) {
+            return self.senders.availableForValidation.selected && self.senders.availableForValidation.selected[sender.sender];
+        });
     };
 
     /* -----  End of HELPERS  ------*/
@@ -78,7 +74,8 @@ angular.module("managerApp").controller("TelecomSmsSendersAddCtrl", function ($q
             return Sms.Senders().Lexi().create({
                 serviceName: $stateParams.serviceName
             }, {
-                sender: sender.sender
+                sender: sender.sender,
+                reason: "sendersAvailableForValidation"
             }).$promise;
         });
         self.loading.adding = true;


### PR DESCRIPTION
Currently API return this error when I want to add selected senders:

```json
{"message":"Please provide a reason"}
```