### PR TITLE
chore(deps): renamed to ovh-angular-a-disabled.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -71,7 +71,7 @@
     "ng-csv": "^0.3.6",
     "ngSmoothScroll": "~1.7.1",
     "oclazyload": "0.5.2",
-    "ovh-angular-a-disabled": "^0.1.0",
+    "ovh-angular-a-disabled": "^0.1.1",
     "ovh-angular-apiv7": "^1.1.1",
     "ovh-angular-browser-alert": "^0.0.5",
     "ovh-angular-checkbox-table": "^0.1.2",

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,7 +1,7 @@
 angular.module("managerApp", [
     "ovh-angular-sso-auth",
     "ovh-angular-sso-auth-modal-plugin",
-    "angular-a-disabled",
+    "ovh-angular-a-disabled",
     "angular-ellipses",
     "ovh-angular-timeline",
     "ovh-angular-ui-confirm-modal",


### PR DESCRIPTION
Since we released a new version of `ovh-angular-a-disabled`, we updated the name of the module.