### PR TITLE
fix(xdsl wifi): get the default wifi by default when many wifi available

### DIFF
--- a/client/app/telecom/pack/xdsl/modem/wifi/config/pack-xdsl-modem-wifi-config.controller.js
+++ b/client/app/telecom/pack/xdsl/modem/wifi/config/pack-xdsl-modem-wifi-config.controller.js
@@ -117,7 +117,9 @@ angular.module("managerApp")
                     }
                 ).$promise.then(
                     function (data) {
-                        self.wifi = data[0];
+                        self.wifi = _.find(data, {
+                            wifiName: "defaultWIFI"
+                        });
                         self.wifi.channelCustom = self.wifi.channelMode === "Auto" ? "Auto" : self.wifi.channel;
                         self.loaders.wifi = false;
                         return data;

--- a/client/app/telecom/pack/xdsl/modem/wifi/pack-xdsl-modem-wifi.controller.js
+++ b/client/app/telecom/pack/xdsl/modem/wifi/pack-xdsl-modem-wifi.controller.js
@@ -42,7 +42,9 @@ angular.module("managerApp").controller("XdslModemWifiCtrl", function ($statePar
             xdslId: $stateParams.serviceName
         }).$promise.then(
             function (data) {
-                self.wifi = data[0];
+                self.wifi = _.find(data, {
+                    wifiName: "defaultWIFI"
+                });
                 self.undoData = {
                     enabled: self.wifi ? self.wifi.enabled : false
                 };


### PR DESCRIPTION
Quick win before enabling all wifi networks management.
Instead of managing first wifi in API list, allow to manage the default wifi.
