### PR TITLE
fix(overTheBox): Use devices for Graph

### DIFF
--- a/client/app/telecom/overTheBox/details/overTheBox-details.controller.js
+++ b/client/app/telecom/overTheBox/details/overTheBox-details.controller.js
@@ -378,7 +378,7 @@ angular.module("managerApp").controller("OverTheBoxDetailsCtrl", function ($scop
                 self.kpiInterfaces = devices.networkInterfaces.filter(function (netInterface) {
                     return netInterface.gateway != null;
                 }).map(function (netInterface) {
-                    return netInterface.name;
+                    return netInterface.device ? netInterface.device : netInterface.name;
                 });
                 return devices;
             }


### PR DESCRIPTION
Instead of filtering on the interface name only, we need to filter on
the device if it's defined, or fallback to the interface name
Without that, all devices up to date ( >= 0.6 ) will only see tun0
graphs

Signed-off-by: Lucas BEE <lucas.bee@corp.ovh.com>

## overTheBox : Use devices for Graphs


### Description of the Change

We need to filter graphs interfaces on devices rather than interfaces. Right now devices in version >= 0.6 aren't able to display their graphs

### Benefits

With this fix, all the users will have their graphs
