### PR TITLE
feat(at-internet): update lib and config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -68,7 +68,7 @@
     "matchmedia-ng": "^1.0.8",
     "messenger": "1.4.1",
     "moment": "^2.15.2",
-    "ng-at-internet": "^2.2.1",
+    "ng-at-internet": "^3.0.0",
     "ng-csv": "^0.3.6",
     "ngSmoothScroll": "~1.7.1",
     "oclazyload": "0.5.2",
@@ -128,6 +128,7 @@
     "jquery-ui": ">=1.12.x",
     "lodash": "~3.10.1",
     "moment": "^2.15.2",
+    "ng-at-internet": "^3.0.0",
     "ovh-font": "~0.15.x",
     "responsive-popover": "^4.0.0",
     "uri.js": "^1.18.1"

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -160,17 +160,30 @@ angular.module("managerApp", [
     })
 
 /*= =========  PAGE TRACKING  ==========*/
-    .config(function (atInternetProvider, atInternetUiRouterPluginProvider, telecomConfig, TRACKING) {
+    .config(function (atInternetProvider, atInternetUiRouterPluginProvider, telecomConfig) {
         "use strict";
 
         var trackingEnabled = telecomConfig.env === "prod";
         atInternetProvider.setEnabled(trackingEnabled);
-        atInternetProvider.setDefaults(TRACKING.atInternetConfiguration);
+        atInternetProvider.setDebug(!trackingEnabled);
         atInternetUiRouterPluginProvider.setTrackStateChange(trackingEnabled);
         atInternetUiRouterPluginProvider.addStateNameFilter(function (routeName) {
             return routeName ? routeName.replace(/\./g, "::") : "";
         });
 
+    })
+    .run(function (atInternet, TRACKING, OvhApiMe) {
+        "use strict";
+
+        var config = TRACKING.atInternetConfiguration;
+
+        OvhApiMe.Lexi().get().$promise
+            .then(function (me) {
+                config.countryCode = me.country;
+                config.currencyCode = me.currency && me.currency.code;
+                config.visitorId = me.customerCode;
+                atInternet.setDefaults(config);
+            });
     })
 
 /*= =========  INTERCEPT ERROR IF NO TRANSLATION FOUND  ==========*/


### PR DESCRIPTION
- Update ng-at-internet lib to 3.0.0 see https://github.com/ovh-ux/ng-at-internet/pull/4
- Update config file (call to ovhApiMe like in manager Cloud) :
   - customerCode instead of nichandle.
   - countryCode
   - currencyCode

Changes has been already made in Cloud see https://github.com/ovh-ux/ovh-manager-cloud/pull/212
PR has been made in Web : https://github.com/ovh-ux/ovh-manager-web/pull/199