### PR TITLE
feature(me-alerts) add new parameter to 2API call

### DIFF
--- a/client/app/config/all.js
+++ b/client/app/config/all.js
@@ -46,6 +46,7 @@ angular.module("managerApp").constant("LANGUAGES", {
     fallback: "fr_FR"
 })
     .constant("UNIVERSE", "TELECOM")
+    .constant("TARGET", "EU")
     .constant("DASHBOARD", {
         services: [
             "xdslAccess",

--- a/client/components/me-alerts/me-alerts.config.js
+++ b/client/components/me-alerts/me-alerts.config.js
@@ -1,13 +1,15 @@
-angular.module("managerApp").run(function ($translate, $translatePartialLoader, Flash, OvhApiMeAlertsAapi, REDIRECT_URLS) {
+angular.module("managerApp").run(function ($translate, $translatePartialLoader, Flash, OvhApiMeAlertsAapi, REDIRECT_URLS, TARGET, UNIVERSE) {
     "use strict";
 
     $translatePartialLoader.addPart("../components/me-alerts");
 
     $translate.refresh().then(function () {
 
-        return OvhApiMeAlertsAapi.query(/* {
-            target: TARGET
-        }*/).$promise.then(function (alerts) {
+        return OvhApiMeAlertsAapi.query({
+            lang: $translate.preferredLanguage(),
+            target: TARGET,
+            universe: UNIVERSE
+        }).$promise.then(function (alerts) {
 
             if (alerts && alerts.length) {
                 var messages = [];


### PR DESCRIPTION
Add curreng manager language and universe to 2API me/alerts call. The new version of me-alerts who will soon be deployed will provide some messages already translated.

### Requirements

The code can be merge with or without new version of the 2api in place. Sooner the better, this will avoid modifying each manager if a new message is return by me-alerts.

### Description of the Change

The same modification is done for each manager, the current language of the manager is can change despite /me and subsidiary. I know telecom manager is not really available in language other than french and english, but if a lang is listed we should should display the message in the prefered language.