### PR TITLE
fix(css -popover): set hidden overflow to back from translated div

### DIFF
--- a/client/app/common/less/popover.less
+++ b/client/app/common/less/popover.less
@@ -223,6 +223,10 @@
                     transform: translateX(-(@page-width));
                 }
 
+                &:not(.move) {
+                    overflow: hidden;
+                }
+
                 .popover-page {
                     width: @page-width;
                 }

--- a/client/app/common/less/popover.less
+++ b/client/app/common/less/popover.less
@@ -53,6 +53,7 @@
             }
 
             section {
+                position: relative;
                 overflow-y: auto;
 
                 .alert {


### PR DESCRIPTION
## Title of the Pull Requests
Fix reverse translate x of popover

### Description of the Change
Into popover with multiple pages, if user scroll the choose an item, back movement hides first page.
Fix is to set overflow hidden to get back properly to origin page