### PR TITLE
fix(alias): add error message if menu cannot be deleted

### DIFF
--- a/client/app/telecom/telephony/alias/configuration/ovhPabx/menus/telecom-telephony-alias-configuration-ovhPabx-menus.html
+++ b/client/app/telecom/telephony/alias/configuration/ovhPabx/menus/telecom-telephony-alias-configuration-ovhPabx-menus.html
@@ -14,6 +14,8 @@
         </div>
         <!-- END OF SHOW LOADING -->
 
+        <toast-message></toast-message>
+
         <!-- NOT AN OVHPABX -->
         <div class="row"
              data-ng-if="!$ctrl.loading.init && ($ctrl.number.getFeatureFamily() !== 'ovhPabx' || ($ctrl.number.feature.featureType === 'cloudHunting' && !$ctrl.number.feature.isCcs()))">

--- a/client/components/telecom/telephony/group/number/feature/ovhPabx/menu/list/telephony-group-number-feature-ovh-pabx-menu-list.component.controller.js
+++ b/client/components/telecom/telephony/group/number/feature/ovhPabx/menu/list/telephony-group-number-feature-ovh-pabx-menu-list.component.controller.js
@@ -52,7 +52,7 @@ angular.module("managerApp").controller("telephonyNumberOvhPabxMenuListCtrl", fu
             if (error.status === 403) {
                 errorTranslationKey = "telephony_number_feature_ovh_pabx_menu_list_delete_error_used";
             }
-            Toast.error([$translate.instant(errorTranslationKey), _.get(error, "data.message") || ""].join(" "));
+            Toast.error([$translate.instant(errorTranslationKey)].join(" "));
             return $q.reject(error);
         }).finally(function () {
             self.askedMenuDelete = null;


### PR DESCRIPTION
## Title of the Pull Requests
Menu deletion error message

### Description of the Change
In alias configuration menu page, if a menu is deleted while it is used by another one, an error message is displayed