### PR TITLE
fix(sms options recredit): amount typo

### DIFF
--- a/client/app/telecom/sms/options/recredit/translations/Messages_fr_FR.xml
+++ b/client/app/telecom/sms/options/recredit/translations/Messages_fr_FR.xml
@@ -23,7 +23,7 @@
    <translation id="sms_options_recredit_update_threshold_error_min" qtlid="338963">La valeur minimum de ce champ doit être de 0.</translation>
    <translation id="sms_options_recredit_update_threshold_error_number" qtlid="340484">Veuillez renseigner un numéro valide.</translation>
    <translation id="sms_options_recredit_update_quantity_label" qtlid="340497">Quantité à recharger</translation>
-   <translation id="sms_options_recredit_update_quantity_option" qtlid="340510">{{ amout }} crédits</translation>
+   <translation id="sms_options_recredit_update_quantity_option">{{ amount }} crédits</translation>
    <translation id="sms_options_recredit_updating" qtlid="340523">Configuration de la recharge automatique…</translation>
    <translation id="sms_options_recredit_updated" qtlid="340536">Configuration de la recharge automatique effectuée</translation>
    <translation id="sms_options_recredit_update_ko" qtlid="340549">Impossible de mettre à jour la configuration de la recharge automatique.<br/>{{error}}</translation>

--- a/client/app/telecom/sms/options/recredit/update/telecom-sms-options-recredit-update.html
+++ b/client/app/telecom/sms/options/recredit/update/telecom-sms-options-recredit-update.html
@@ -65,7 +65,7 @@
                     id="amount"
                     class="form-control"
                     data-ng-model="OptionsRecreditUpdateCtrl.model.service.automaticRecreditAmount"
-                    data-ng-options="amout as ('sms_options_recredit_update_quantity_option' | translate:{ amout: amout }) for amout in OptionsRecreditUpdateCtrl.availablePackQuantity"
+                    data-ng-options="amount as ('sms_options_recredit_update_quantity_option' | translate:{ amount: amount }) for amount in OptionsRecreditUpdateCtrl.availablePackQuantity"
                     data-ng-change="OptionsRecreditUpdateCtrl.getAmount()">
                     <option value=""
                             data-translate="sms_options_recredit_manage_quantity_empty_text">


### PR DESCRIPTION
## SMS Options recredit — amount typo

### Description of the Change

4c9a0e9 — fix(sms options recredit): amount typo
