### PR TITLE
fix(package engines): require node 8 current lts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "sms"
   ],
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=8"
   },
   "scripts": {
     "start": "node server/app.js",


### PR DESCRIPTION
## Require node >=8 current LTS

### Description of the Change

27873b2 — fix(package engines): require node 8 current lts

