### PR TITLE
fix(telephony options group): use heading attribut on oui-back-button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -98,9 +98,9 @@
     "ovh-manager-webfont": "^1.0.1",
     "ovh-ng-input-password": "^1.2.5",
     "ovh-ngstrap": "^4.0.2",
-    "ovh-ui-kit": "~2.15.x",
-    "ovh-ui-kit-bs": "~1.1.x",
-    "ovh-ui-angular": "~2.15.x",
+    "ovh-ui-kit": "~2.16.x",
+    "ovh-ui-kit-bs": "~1.2.x",
+    "ovh-ui-angular": "~2.16.x",
     "validator-js": "3.40.1"
   },
   "devDependencies": {
@@ -131,8 +131,8 @@
     "ovh-font": "~0.15.x",
     "responsive-popover": "^4.0.0",
     "uri.js": "^1.18.1",
-    "ovh-ui-kit": "~2.15.x",
-    "ovh-ui-angular": "~2.15.x"
+    "ovh-ui-kit": "~2.16.x",
+    "ovh-ui-angular": "~2.16.x"
   },
   "overrides": {
     "jquery-ui": {

--- a/client/app/telecom/telephony/billingAccount/administration/optionsGroup/telecom-telephony-billing-account-administration-options-group.html
+++ b/client/app/telecom/telephony/billingAccount/administration/optionsGroup/telecom-telephony-billing-account-administration-options-group.html
@@ -9,7 +9,7 @@
 
         <toast-message></toast-message>
 
-        <oui-back-button data-title="{{:: 'telephony_options_group_title' | translate }}"
+        <oui-back-button data-heading="{{:: 'telephony_options_group_title' | translate }}"
                          data-href="{{ OptionsGroupCtrl.$state.href('telecom.telephony.administration') }}">
         </oui-back-button>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ovh-manager-telecom",
-  "version": "10.4.9",
+  "version": "10.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Use `heading` attribut on `oui-back-button`

### Description of the Change

bb491fa — chore(deps): bump ovh-ui-kit, ovh-ui-kit-bs and ovh-ui-angular
41c68ce — fix(telephony options group): use heading attribut on oui-back-button

ref: https://github.com/ovh-ux/ovh-ui-angular/commit/5ddc0ef2edba5898b97fcca0a73124d369432778#diff-c9aba9326a8bbfe4300255981d64e080R12

/cc @jleveugle @Jisay @frenautvh 