### PR TITLE
fix(telephony): missing alias options for function keys line phone

### DIFF
--- a/client/app/telecom/telephony/line/phone/programmableKeys/edit/telecom-telephony-line-phone-programmableKeys-edit.controller.js
+++ b/client/app/telecom/telephony/line/phone/programmableKeys/edit/telecom-telephony-line-phone-programmableKeys-edit.controller.js
@@ -238,10 +238,11 @@ angular.module('managerApp')
     }
 
     function getCloudHuntingParameter() {
+      const allowedFeatureTypes = ['cloudHunting', 'contactCenterSolution', 'contactCenterSolutionExpert'];
       return TelephonyMediator.getGroup($stateParams.billingAccount).then(() => {
         angular.forEach(TelephonyMediator.groups, (group) => {
           angular.forEach(group.numbers, (number) => {
-            if (number.feature.featureType === 'cloudHunting') {
+            if (_.includes(allowedFeatureTypes, number.feature.featureType)) {
               _.set(number, 'billingAccount', group.description || group.billingAccount);
               self.availableParameters.push(number);
             }


### PR DESCRIPTION
## Allow alias type for function keys line phone options

Add contact center solutions (expert or not) to allowed aliases for easy hunting, in line phone function keys page

MFRWW-710