### PR TITLE
fix(oui-action-menu-item): remove deprecated text attribut

### DIFF
--- a/client/app/telecom/pack/xdsl/modem/wifi/config/pack-xdsl-modem-wifi-config.html
+++ b/client/app/telecom/pack/xdsl/modem/wifi/config/pack-xdsl-modem-wifi-config.html
@@ -27,11 +27,11 @@
 
 
                 <oui-datagrid data-rows="ConfigWifiCtrl.wifis" data-page-size="10">
-                    <oui-column data-title="'xdsl_modem_wifi_config_table_ssid' | translate" 
+                    <oui-column data-title="'xdsl_modem_wifi_config_table_ssid' | translate"
                                 data-property="SSID" data-sortable="asc">
                         {{$row.SSID}}
                     </oui-column>
-                    <oui-column data-title="'xdsl_modem_wifi_config_ssid_table_visibility' | translate" 
+                    <oui-column data-title="'xdsl_modem_wifi_config_ssid_table_visibility' | translate"
                                 data-property="SSIDAdvertisementEnabled" data-sortable>
                         <span data-translate="{{ $row.SSIDAdvertisementEnabled ? 'xdsl_modem_wifi_config_visible' : 'xdsl_modem_wifi_config_hidden' }}">
                         </span>
@@ -67,9 +67,8 @@
                     </oui-column>
 
                     <oui-action-menu data-align="end" data-compact>
-                        <oui-action-menu-item
-                                data-text="{{'edit' | translate}}"
-                                on-click="ConfigWifiCtrl.setSelectedWifi($row)">
+                        <oui-action-menu-item on-click="ConfigWifiCtrl.setSelectedWifi($row)">
+                            <span data-translate="edit"></span>
                         </oui-action-menu-item>
                     </oui-action-menu>
 

--- a/client/app/telecom/sms/options/response/telecom-sms-options-response.html
+++ b/client/app/telecom/sms/options/response/telecom-sms-options-response.html
@@ -201,15 +201,12 @@
                     </oui-column>
 
                     <oui-action-menu data-align="end" data-compact>
-                            <oui-action-menu-item
-                                data-text="{{'edit' | translate}}"
-                                on-click="TelecomSmsOptionsResponseCtrl.editTrackingOptions($index, $row)">
-                            </oui-action-menu-item>
-
-                            <oui-action-menu-item
-                                data-text="{{'delete' | translate}}"
-                                on-click="TelecomSmsOptionsResponseCtrl.removeTrackingOptions($index, $row)">
-                            </oui-action-menu-item>
+                        <oui-action-menu-item on-click="TelecomSmsOptionsResponseCtrl.editTrackingOptions($index, $row)">
+                            <span data-translate="edit"></span>
+                        </oui-action-menu-item>
+                        <oui-action-menu-item on-click="TelecomSmsOptionsResponseCtrl.removeTrackingOptions($index, $row)">
+                            <span data-translate="delete"></span>
+                        </oui-action-menu-item>
                     </oui-action-menu>
                 </oui-datagrid>
 

--- a/client/app/telecom/sms/sms/templates/telecom-sms-sms-templates.html
+++ b/client/app/telecom/sms/sms/templates/telecom-sms-sms-templates.html
@@ -128,19 +128,14 @@
             </oui-column>
 
             <oui-action-menu data-align="end" data-compact>
-                <oui-action-menu-item
-                    data-text="{{'edit' | translate}}"
-                    on-click="$ctrl.edit($row)">
+                <oui-action-menu-item on-click="$ctrl.edit($row)">
+                    <span data-translate="edit"></span>
                 </oui-action-menu-item>
-
-                <oui-action-menu-item
-                    data-text="{{'common_relaunch' | translate}}"
-                    on-click="$ctrl.relaunch($row)">
+                <oui-action-menu-item on-click="$ctrl.relaunch($row)">
+                    <span data-translate="common_relaunch"></span>
                 </oui-action-menu-item>
-
-                <oui-action-menu-item
-                    data-text="{{'delete' | translate}}"
-                    on-click="$ctrl.remove($row)">
+                <oui-action-menu-item on-click="$ctrl.remove($row)">
+                    <span data-translate="delete"></span>
                 </oui-action-menu-item>
             </oui-action-menu>
         </oui-datagrid>

--- a/client/app/telecom/sms/users/telecom-sms-users.html
+++ b/client/app/telecom/sms/users/telecom-sms-users.html
@@ -103,35 +103,25 @@
                     data-tooltip-append-to-body="true">
                 </span>
             </oui-column>
-            <oui-action-menu align="end" compact>
-                    <oui-action-menu-item
-                        data-text="{{'sms_users_action_change_password_label' | translate}}"
-                        on-click="SmsUsersCtrl.changePassword($row)">
+            <oui-action-menu data-align="end"
+                             data-compact>
+                    <oui-action-menu-item on-click="SmsUsersCtrl.changePassword($row)">
+                        <span data-translate="sms_users_action_change_password_label"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item
-                        data-text="{{'sms_users_action_quota' | translate}}"
-                        on-click="SmsUsersCtrl.quota($row)">
+                    <oui-action-menu-item on-click="SmsUsersCtrl.quota($row)">
+                        <span data-translate="sms_users_action_quota"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item
-                        data-text="{{'sms_users_action_limit' | translate}}"
-                        on-click="SmsUsersCtrl.limit($row)">
+                    <oui-action-menu-item on-click="SmsUsersCtrl.limit($row)">
+                        <span data-translate="sms_users_action_limit"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item
-                        data-text="{{'sms_users_action_restriction_ip_label' | translate}}"
-                        on-click="SmsUsersCtrl.restrict($row)">
+                    <oui-action-menu-item on-click="SmsUsersCtrl.restrict($row)">
+                        <span data-translate="sms_users_action_restriction_ip_label"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item
-                        data-text="{{'sms_users_action_url_callback_label' | translate}}"
-                        on-click="SmsUsersCtrl.callback($row)">
+                    <oui-action-menu-item on-click="SmsUsersCtrl.callback($row)">
+                        <span data-translate="sms_users_action_url_callback_label"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item
-                        data-text="{{'delete' | translate}}"
-                        on-click="SmsUsersCtrl.remove($row)">
+                    <oui-action-menu-item on-click="SmsUsersCtrl.remove($row)">
+                        <span data-translate="delete"></span>
                     </oui-action-menu-item>
             </oui-action-menu>
         </oui-datagrid>

--- a/client/app/telecom/telephony/billingAccount/billing/bill/telecom-telephony-billing-account-billing-bill.html
+++ b/client/app/telecom/telephony/billingAccount/billing/bill/telecom-telephony-billing-account-billing-bill.html
@@ -30,16 +30,14 @@
                 </oui-column>
 
                 <oui-action-menu data-align="end" data-compact>
-                    <oui-action-menu-item data-text="{{'telephony_group_billing_bill_download_pdf' | translate}}"
-                                          on-click="BillingAccountBillCtrl.download($row, 'pdf')">
+                    <oui-action-menu-item on-click="BillingAccountBillCtrl.download($row, 'pdf')">
+                        <span data-translate="telephony_group_billing_bill_download_pdf"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item data-text="{{'telephony_group_billing_bill_download_csv_emited' | translate}}"
-                                          on-click="BillingAccountBillCtrl.download($row, 'csv')">
+                    <oui-action-menu-item on-click="BillingAccountBillCtrl.download($row, 'csv')">
+                        <span data-translate="telephony_group_billing_bill_download_csv_emited"></span>
                     </oui-action-menu-item>
-
-                    <oui-action-menu-item data-text="{{'telephony_group_billing_bill_download_csv_received' | translate}}"
-                                          on-click="BillingAccountBillCtrl.download($row, 'received.csv')">
+                    <oui-action-menu-item on-click="BillingAccountBillCtrl.download($row, 'received.csv')">
+                        <span data-translate="telephony_group_billing_bill_download_csv_received"></span>
                     </oui-action-menu-item>
                 </oui-action-menu>
             </oui-datagrid>

--- a/client/app/telecom/telephony/billingAccount/billing/repaymentHistory/telecom-telephony-billing-account-billing-repayment-history.html
+++ b/client/app/telecom/telephony/billingAccount/billing/repaymentHistory/telecom-telephony-billing-account-billing-repayment-history.html
@@ -46,8 +46,8 @@
                         </oui-column>
 
                         <oui-action-menu data-align="end" data-compact>
-                            <oui-action-menu-item data-text="{{'telephony_group_billing_repayment_history_list_download_csv' | translate}}"
-                                                  on-click="RepaymentHistoryCtrl.download($row)">
+                            <oui-action-menu-item on-click="RepaymentHistoryCtrl.download($row)">
+                                <span data-translate="telephony_group_billing_repayment_history_list_download_csv"></span>
                             </oui-action-menu-item>
                         </oui-action-menu>
 

--- a/client/app/telecom/telephony/billingAccount/billing/tollfreeHistory/telecom-telephony-billing-account-billing-tollfree-history.html
+++ b/client/app/telecom/telephony/billingAccount/billing/tollfreeHistory/telecom-telephony-billing-account-billing-tollfree-history.html
@@ -21,13 +21,13 @@
                 <div class="col-xs-12">
 
                     <oui-datagrid data-rows="TollfreeHistoryCtrl.consumptionData">
-                        <oui-column data-title="'telephony_group_billing_tollfree_history_list_date' | translate" 
+                        <oui-column data-title="'telephony_group_billing_tollfree_history_list_date' | translate"
                                     data-property="date" data-sortable="desc">
                             <span class="text-nowrap"
                                 data-ng-bind="$row.date | date:'shortDate'">
                             </span>
                         </oui-column>
-                        <oui-column data-title="'telephony_group_billing_tollfree_history_list_price' | translate" 
+                        <oui-column data-title="'telephony_group_billing_tollfree_history_list_price' | translate"
                                     data-property="date" data-sortable>
                             <span class="text-nowrap"
                                   data-ng-bind="$row.price.text.replace('-', '')">
@@ -35,8 +35,8 @@
                         </oui-column>
 
                         <oui-action-menu data-align="end" data-compact>
-                            <oui-action-menu-item data-text="{{'telephony_group_billing_tollfree_history_list_download_csv' | translate}}"
-                                                  on-click="TollfreeHistoryCtrl.download($row)">
+                            <oui-action-menu-item on-click="TollfreeHistoryCtrl.download($row)">
+                                <span data-translate="telephony_group_billing_tollfree_history_list_download_csv"></span>
                             </oui-action-menu-item>
                         </oui-action-menu>
 

--- a/client/app/telecom/telephony/billingAccount/dashboard/telecom-telephony-billing-account-dashboard.html
+++ b/client/app/telecom/telephony/billingAccount/dashboard/telecom-telephony-billing-account-dashboard.html
@@ -228,16 +228,14 @@
                     </oui-column>
 
                     <oui-action-menu data-align="end" data-compact>
-                        <oui-action-menu-item data-text="{{'telephony_group_billing_dashboard_bill_download_pdf' | translate}}"
-                                              on-click="DashboardCtrl.download($row, 'pdf')">
+                        <oui-action-menu-item on-click="DashboardCtrl.download($row, 'pdf')">
+                            <span data-translate="telephony_group_billing_dashboard_bill_download_pdf"></span>
                         </oui-action-menu-item>
-        
-                        <oui-action-menu-item data-text="{{'telephony_group_billing_dashboard_bill_download_csv_emited' | translate}}"
-                                              on-click="DashboardCtrl.download($row, 'csv')">
+                        <oui-action-menu-item on-click="DashboardCtrl.download($row, 'csv')">
+                            <span data-translate="telephony_group_billing_dashboard_bill_download_csv_emited"></span>
                         </oui-action-menu-item>
-
-                        <oui-action-menu-item data-text="{{'telephony_group_billing_dashboard_bill_download_csv_received' | translate}}"
-                                              on-click="DashboardCtrl.download($row, 'received.csv')">
+                        <oui-action-menu-item on-click="DashboardCtrl.download($row, 'received.csv')">
+                            <span data-translate="telephony_group_billing_dashboard_bill_download_csv_received"></span>
                         </oui-action-menu-item>
                     </oui-action-menu>
                 </oui-datagrid>

--- a/client/app/telecom/telephony/line/phone/programmableKeys/telecom-telephony-line-phone-programmableKeys.html
+++ b/client/app/telecom/telephony/line/phone/programmableKeys/telecom-telephony-line-phone-programmableKeys.html
@@ -47,8 +47,8 @@
                 </oui-column>
 
                 <oui-action-menu data-align="end" data-compact>
-                    <oui-action-menu-item data-text="{{'edit' | translate}}"
-                                          on-click="ProgrammableKeysCtrl.edit($row)">
+                    <oui-action-menu-item on-click="ProgrammableKeysCtrl.edit($row)">
+                        <span data-translate="edit"></span>
                     </oui-action-menu-item>
                 </oui-action-menu>
             </oui-datagrid>


### PR DESCRIPTION
## Remove deprecated text attribut

### Description of the Change

⚠️ This is a temporary fix

25935a7 — fix(oui-action-menu-item): remove deprecated text attribut

### Benefits

Item text value isn't displayed.

capture before:
<img width="173" alt="capture-1" src="https://user-images.githubusercontent.com/428384/44297911-bc90a880-a2d9-11e8-9ccd-8a9f6c5f97ca.png">

capture: after:
<img width="172" alt="capture-2" src="https://user-images.githubusercontent.com/428384/44297912-c0bcc600-a2d9-11e8-8a0b-afd4eeaa2b4a.png">

### Possible Drawbacks

Bug introduced since we bumped to [`ovh-ui-angular@v2.18.0`](https://github.com/ovh-ux/ovh-ui-angular/releases/tag/v2.18.0). 

### Applicable Issues

Other managers could be impacted if we upgrade to `ovh-ui-angular@v2.18.0`.

/cc @lizardK @jleveugle @Jisay @frenautvh @cbourgois 

