### PR TITLE
fix(call forwarding): call forwarding selection

### DIFF
--- a/client/app/telecom/telephony/line/calls/forward/telecom-telephony-line-calls-forward.controller.js
+++ b/client/app/telecom/telephony/line/calls/forward/telecom-telephony-line-calls-forward.controller.js
@@ -246,7 +246,6 @@ angular.module('managerApp').controller('TelecomTelephonyLineCallsForwardCtrl', 
     }).then(loadAllOvhNumbers).then(loadNatures)
       .then(loadForwards)
       .finally(() => {
-        self.resetNumbers();
         self.loading.init = false;
       });
   }


### PR DESCRIPTION
MFRWW-827

### Requirements

The selection of line in the unconditional call forwarding is not retained on refresh. This has to be fixed.

## Unconditional Call forwarding Selection Retention


### Description of the Change

On page load, the selected line is being reset to the first matching line. This has been removed to retain the previously selected line.