### PR TITLE
fix(guide-url): sms guide url not working

### DIFF
--- a/client/app/telecom/sms/telecom-sms.constant.js
+++ b/client/app/telecom/sms/telecom-sms.constant.js
@@ -36,7 +36,7 @@ angular
           {
             label: 'sms_guides_compose_email',
             url: {
-              fr: 'https://www.ovh.com/fr/g2143.{title}',
+              fr: 'https://docs.ovh.com/fr/sms/envoyer-sms-depuis-adresse-email/#gestion-des-destinataires',
             },
           },
           {


### PR DESCRIPTION
## Fix for sms guide url in manager

### Description of the Change

replace guide for sending sms from email address

### Benefits

Points to the right guide url

### Possible Drawbacks

None

### Applicable Issues

MFRWW-857