### PR TITLE
refactor(components): init telecomUniverseComponents module

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,4 +1,5 @@
 import asyncLoaderFactory from './async-loader.factory';
+import telecomUniverseComponents from '../telecomUniverseComponents';
 
 angular.module('managerApp', [
   'ovh-angular-sso-auth',
@@ -58,6 +59,7 @@ angular.module('managerApp', [
   'ovh-angular-actions-menu',
   'ovh-angular-sidebar-menu',
   'angular-translate-loader-pluggable',
+  telecomUniverseComponents,
 ])
 
 /*= =========  GLOBAL OPTIONS  ========== */

--- a/client/telecomUniverseComponents/index.js
+++ b/client/telecomUniverseComponents/index.js
@@ -1,0 +1,5 @@
+import angular from 'angular';
+
+export default angular
+  .module('telecomUniverseComponents', [])
+  .name;


### PR DESCRIPTION
## Init `telecomUniverseComponents` module

### Description of the Change

b9f06a7 — refactor(components): init telecomUniverseComponents module

In order to move all telecom components to the `one-manager` we will refactor them in a more appropriate way.

/cc @jleveugle @frenautvh @cbourgois 