### PR TITLE
fix(sms.options): fix editing and deleting sms response options

### DIFF
--- a/client/app/telecom/sms/options/response/edit/telecom-sms-options-response-edit.controller.js
+++ b/client/app/telecom/sms/options/response/edit/telecom-sms-options-response-edit.controller.js
@@ -61,24 +61,22 @@ angular
         target: this.model.option.target,
       };
       this.loading.editTrackingOption = true;
-      return this.$q.all([
-        this.api.sms.edit({
-          serviceName: this.$stateParams.serviceName,
-        }, {
-          smsResponse: {
-            trackingOptions: this.model.service.smsResponse.trackingOptions,
-            responseType: this.model.service.smsResponse.responseType,
-          },
-        }).$promise,
-        this.$timeout(angular.noop, 1000),
-      ]).then(() => {
-        this.loading.editTrackingOption = false;
-        this.edited = true;
-        return this.$timeout(() => this.close(), 1000);
-      }).catch(error => this.cancel({
-        type: 'API',
-        msg: error,
-      }));
+      return this.api.sms.edit({
+        serviceName: this.$stateParams.serviceName,
+      }, {
+        smsResponse: {
+          trackingOptions: this.model.service.smsResponse.trackingOptions,
+          responseType: this.model.service.smsResponse.responseType,
+        },
+      }).$promise
+        .then(() => {
+          this.loading.editTrackingOption = false;
+          this.edited = true;
+          return this.$timeout(() => this.close(), 1000);
+        }).catch(error => this.cancel({
+          type: 'API',
+          msg: error,
+        }));
     }
 
     /**

--- a/client/app/telecom/sms/options/response/telecom-sms-options-response.html
+++ b/client/app/telecom/sms/options/response/telecom-sms-options-response.html
@@ -201,10 +201,10 @@
                     </oui-column>
 
                     <oui-action-menu data-align="end" data-compact>
-                        <oui-action-menu-item on-click="TelecomSmsOptionsResponseCtrl.editTrackingOptions($index, $row)">
+                        <oui-action-menu-item on-click="TelecomSmsOptionsResponseCtrl.editTrackingOptions($rowIndex, $row)">
                             <span data-translate="edit"></span>
                         </oui-action-menu-item>
-                        <oui-action-menu-item on-click="TelecomSmsOptionsResponseCtrl.removeTrackingOptions($index, $row)">
+                        <oui-action-menu-item on-click="TelecomSmsOptionsResponseCtrl.removeTrackingOptions($rowIndex, $row)">
                             <span data-translate="delete"></span>
                         </oui-action-menu-item>
                     </oui-action-menu>


### PR DESCRIPTION
## Fix SMS notification edit and deletion

### Description of the Change
 
Before: Editing was not working and all notification were deleted at once 

### Waiting for 

- [x] https://github.com/ovh-ux/ovh-ui-angular/pull/296

MANAGER-1756
