### PR TITLE
fix(sidebar): change less variable case

### DIFF
--- a/client/components/sidebar/sidebar.less
+++ b/client/components/sidebar/sidebar.less
@@ -1,5 +1,5 @@
 // MANAGER SIDEBAR
-@sidebar_menu_active_color: @oui-color-dodger;
+@SIDEBAR_MENU_ACTIVE_COLOR: @oui-color-dodger;
 // ACTIONS MENU (TO BE MOVED LATER)
 @actions-menu-item-border-color: @gray-lighter;
 @actions-menu-item-link-icon-color: #143f6c;


### PR DESCRIPTION
## fix(sidebar): change less variable case

### Description of the Change

Before sidebar menu active color was `#ffffff`, now it's `@oui-color-dodger` (`#32acff`)
Related to https://github.com/ovh-ux/ovh-manager-telecom/commit/8570e5a98a9281eedfb59b66e74f8ee2ff3afa6c#diff-01c818d7fdf126407c8f8307543311a3R2

03acf296 - fix(sidebar): change less variable case


/cc @jleveugle @frenautvh @antleblanc

