### PR TITLE
fix(telephony.alias): undo deletion of used folder

### DIFF
--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add-modal.component.js
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add-modal.component.js
@@ -1,0 +1,13 @@
+angular.module('managerApp').controller('telecomTelephonyAliasMembersAddModal', class telecomTelephonyAliasMembersAddModal {
+  constructor($uibModalInstance) {
+    this.$uibModalInstance = $uibModalInstance;
+  }
+
+  cancel(message) {
+    return this.$uibModalInstance.dismiss(message);
+  }
+
+  close() {
+    return this.$uibModalInstance.close(true);
+  }
+});

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add-modal.html
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add-modal.html
@@ -1,0 +1,30 @@
+<form data-ng-submit="$ctrl.close()">
+    <div class="modal-header">
+        <button
+            type="button"
+            class="close float-right"
+            aria-label="{{ ::'cancel' | translate }}"
+            data-ng-click="$ctrl.cancel()">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+
+    <div class="modal-body">
+        <p data-translate="telephony_alias_members_add_modal-warning"></p>
+        <p data-translate="telephony_alias_members_add_modal-question"></p>
+    </div>
+
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-default"
+            data-ng-click="$ctrl.cancel()"
+            data-translate="cancel">
+        </button>
+        <button
+            type="submit"
+            class="btn btn-primary"
+            data-translate="submit">
+        </button>
+    </div>
+</form>

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add.component.js
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add.component.js
@@ -1,0 +1,89 @@
+angular.module('managerApp').component('telecomTelephonyAliasMembersAdd', {
+  bindings: {
+    api: '=',
+  },
+  templateUrl: 'components/telecom/telephony/alias/members/telecom-telephony-alias-members-add.html',
+  controller($q, $translate, $translatePartialLoader, $uibModal, TucToast, TucToastError) {
+    const self = this;
+
+    self.$onInit = function () {
+      self.addMemberForm = {
+        numbers: [null],
+        options: {},
+      };
+
+      self.loaders = {
+        adding: false,
+      };
+
+      // list of already added services
+      self.servicesToExclude = [];
+
+      // forms
+      self.resetMemberAddForm();
+
+      $translatePartialLoader.addPart('../components/telecom/telephony/alias/members');
+      return $translate.refresh().finally(() => {
+        self.isInitialized = true;
+        return self.refreshMembers().catch(err => new TucToastError(err));
+      });
+    };
+
+    self.onChooseServicePopover = function (service, pos) {
+      self.addMemberForm.numbers[pos] = service.serviceName;
+    };
+
+    self.resetMemberAddForm = function () {
+      self.addMemberForm.numbers = [null];
+      self.addMemberForm.options = {
+        timeout: 20,
+        wrapUpTime: 1,
+        simultaneousLines: 1,
+        status: 'available',
+      };
+    };
+
+    self.getServicesToExclude = function () {
+      const services = _.pluck(self.api.getMemberList(), 'number').concat(self.addMemberForm.numbers);
+      self.servicesToExclude.splice(0, self.servicesToExclude.length);
+      _.each(services, (s) => {
+        self.servicesToExclude.push(s);
+      });
+      return self.servicesToExclude;
+    };
+
+    self.addMembers = function (form) {
+      const modal = $uibModal.open({
+        animation: true,
+        templateUrl: 'components/telecom/telephony/alias/members/telecom-telephony-alias-members-add-modal.html',
+        controller: 'telecomTelephonyAliasMembersAddModal',
+        controllerAs: '$ctrl',
+      });
+      modal.result.then(() => {
+        self.loaders.adding = true;
+        return self.api
+          .addMembers(_(self.addMemberForm.numbers)
+            .filter(number => number && number.length)
+            .map(number => _.assign({ number }, self.addMemberForm.options))
+            .value())
+          .then(() => {
+            TucToast.success($translate.instant('telephony_alias_members_add_success'));
+            self.resetMemberAddForm();
+            form.$setPristine();
+          })
+          .catch(err => new TucToastError(err))
+          .finally(() => {
+            self.loaders.adding = false;
+          });
+      });
+    };
+
+    self.removeMemberAt = function (index) {
+      if (index === 0 && self.addMemberForm.numbers.length === 1) {
+        self.addMemberForm.numbers[0] = null;
+      } else {
+        _.pullAt(self.addMemberForm.numbers, index);
+      }
+    };
+  },
+});

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add.html
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members-add.html
@@ -1,0 +1,121 @@
+<form id="memberAddForm"
+      name="memberAddForm"
+      data-ng-submit="$ctrl.addMembers(memberAddForm)"
+      data-ng-if="$ctrl.isInitialized"
+      novalidate>
+
+    <!-- NUMBER -->
+    <div class="form-group">
+        <label for="memberNumber"
+               class="control-label"
+               data-translate="telephony_alias_members_number"></label>
+        <div class="input-group"
+             data-ng-repeat="number in $ctrl.addMemberForm.numbers track by $index">
+            <input id="memberNumber"
+                   class="form-control"
+                   type="text"
+                   placeholder="{{:: 'telephony_alias_members_number_placeholder' | translate }}"
+                   required
+                   data-ng-pattern="/^.*$/"
+                   data-ng-model="$ctrl.addMemberForm.numbers[$index]" />
+            <span class="input-group-btn">
+                <button type="button"
+                        class="btn btn-default"
+                        aria-label="{{:: 'common_search' | translate }}"
+                        data-voip-service-choice-popover="{
+                            popoverPlacement: 'auto left',
+                            popoverClass: 'pretty-popover telephony-service-choice-popover',
+                            popoverAppendToBody: true,
+                            popoverIsOpen: false
+                        }"
+                        data-choice-args="$index"
+                        data-exclude-services="$ctrl.getServicesToExclude()"
+                        data-available-types="['sip', 'number', 'plugAndFax']"
+                        data-on-choice-validated="$ctrl.onChooseServicePopover"
+                        data-on-choice-cancel="">
+                    <i class="ovh-font ovh-font-search"></i>
+                </button>
+                <button type="button"
+                        class="btn btn-default"
+                        aria-label="{{:: 'delete' | translate }}"
+                        data-ng-disabled="$index === 0 && !$ctrl.addMemberForm.numbers[0]"
+                        data-ng-click="$ctrl.removeMemberAt($index)">
+                    <i class="ovh-font ovh-font-wrong"></i>
+                </button>
+            </span>
+        </div>
+    </div>
+
+    <!-- ADD MORE NUMBERS -->
+    <div class="form-group"
+         data-ng-if="$ctrl.addMemberForm.numbers[0]">
+        <button type="button"
+                class="btn btn-default"
+                data-ng-click="$ctrl.addMemberForm.numbers.push(null)"
+                data-translate="telephony_alias_members_number_add"
+                data-ng-disabled="!$ctrl.addMemberForm.numbers[$ctrl.addMemberForm.numbers.length - 1]">
+        </button>
+    </div>
+
+    <!-- TIMEOUT -->
+    <div class="form-group">
+        <label for="timeoutInput"
+               class="control-label"
+               data-translate="telephony_alias_members_timeout"></label>
+        <input-number-spinner class="d-inline-block text-left"
+                              id="timeoutInput"
+                              data-ng-model="$ctrl.addMemberForm.options.timeout"
+                              data-input-number-spinner-min="1"
+                              data-input-number-spinner-max="99999">
+        </input-number-spinner>
+    </div>
+
+    <!-- WRAP UP TIME -->
+    <div class="form-group">
+        <label for="wrapUpTimeInput"
+               class="control-label"
+               data-translate="telephony_alias_members_wrap_up_time"></label>
+        <input-number-spinner class="d-inline-block text-left"
+                              id="wrapUpTimeInput"
+                              data-ng-model="$ctrl.addMemberForm.options.wrapUpTime"
+                              data-input-number-spinner-min="0"
+                              data-input-number-spinner-max="99999">
+        </input-number-spinner>
+    </div>
+
+    <!-- SIMULTANEOUS LINES -->
+    <div class="form-group">
+        <label for="simultaneousLinesInput"
+               class="control-label"
+               data-translate="telephony_alias_members_simultaneous_lines"></label>
+        <input-number-spinner class="d-inline-block text-left"
+                              id="simultaneousLinesInput"
+                              data-ng-model="$ctrl.addMemberForm.options.simultaneousLines"
+                              data-input-number-spinner-min="1"
+                              data-input-number-spinner-max="10">
+        </input-number-spinner>
+    </div>
+
+    <div class="form-group">
+        <button type="button"
+                class="btn btn-default"
+                data-translate="cancel"
+                data-ng-click="$ctrl.resetMemberAddForm()"
+                data-ng-if="$ctrl.addMemberForm.numbers[0]">
+        </button>
+        <button type="submit"
+                class="btn btn-primary"
+                data-ng-disabled="memberAddForm.$invalid || $ctrl.loaders.adding">
+            <oui-spinner class="mr-2"
+                         data-ng-if="$ctrl.loaders.adding"
+                         data-size="s">
+            </oui-spinner>
+            <span data-ng-if="$ctrl.addMemberForm.numbers.length <= 1"
+                  data-translate="telephony_alias_members_add"></span>
+            <span data-ng-if="$ctrl.addMemberForm.numbers.length > 1"
+                  data-translate="telephony_alias_members_add_multiple"
+                  data-translate-values="{ count: $ctrl.addMemberForm.numbers.length }"></span>
+        </button>
+    </div>
+
+</form>

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.component.js
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.component.js
@@ -1,0 +1,161 @@
+angular.module('managerApp').run(($translate, asyncLoader) => {
+  asyncLoader.addTranslations(
+    import(`./translations/Messages_${$translate.use()}.xml`)
+      .catch(() => import(`./translations/Messages_${$translate.fallbackLanguage()}.xml`))
+      .then(x => x.default),
+  );
+  $translate.refresh();
+});
+angular.module('managerApp').component('telecomTelephonyAliasMembers', {
+  bindings: {
+    api: '=',
+  },
+  templateUrl: 'components/telecom/telephony/alias/members/telecom-telephony-alias-members.html',
+  controller($q, $translate, $translatePartialLoader, TucToast, TucToastError) {
+    const self = this;
+
+    self.$onInit = function () {
+      self.loaders = {
+        init: false,
+        deleting: false,
+      };
+      self.sortableMembersOpts = {
+        handle: '.ovh-font-grip',
+        start() {
+          self.membersBeforeDrag = angular.copy(self.members);
+        },
+        stop: self.onMoveMember,
+        disabled: false,
+      };
+      self.members = null;
+      self.membersBeforeDrag = null;
+      self.memberInEdition = null;
+      self.memberToDelete = null;
+
+      $translatePartialLoader.addPart('../components/telecom/telephony/alias/members');
+      return $translate.refresh().finally(() => {
+        self.isInitialized = true;
+        return self.refreshMembers().catch(err => new TucToastError(err)).finally(() => {
+          self.loaders.init = false;
+        });
+      });
+    };
+
+    self.api.addMembersToList = function (toAdd) {
+      _.each(toAdd.reverse(), (member) => {
+        self.members.unshift(member);
+      });
+      self.api.reorderMembers(self.members).then((orderedMembers) => {
+        self.members = orderedMembers;
+      });
+    };
+
+    self.api.getMemberList = function () {
+      return angular.copy(self.members);
+    };
+
+    self.refreshMembers = function () {
+      self.members = null;
+      return self.api.fetchMembers()
+        .then(members => self.api.reorderMembers(members)).then((orderedMembers) => {
+          self.members = orderedMembers;
+        })
+        .catch(err => new TucToastError(err))
+        .finally(() => {
+          self.loaders.init = true;
+        });
+    };
+
+    self.updateMemberDescription = function (member) {
+      if (member.description === undefined) {
+        self.api.fetchMemberDescription(member)
+          .then((result) => {
+            _.set(member, 'description', result);
+          })
+          .catch(() => {
+            _.set(member, 'description', '');
+          });
+      }
+    };
+
+    self.onSwapMembers = function (fromMember, toMember) {
+      const from = angular.copy(fromMember);
+      const to = angular.copy(toMember);
+
+      // we do it by hand first so the ui is refreshed immediately
+      const fromPos = fromMember.position;
+      const toPos = toMember.position;
+      _.set(fromMember, 'position', toPos);
+      _.set(toMember, 'position', fromPos);
+      self.members = _.sortBy(self.members, 'position');
+
+      self.sortableMembersOpts.disabled = true;
+      return self.api
+        .swapMembers(from, to)
+        .then(() => self.api.reorderMembers(self.members))
+        .then((orderedMembers) => {
+          self.members = orderedMembers;
+        })
+        .catch((err) => {
+          // revert changes
+          _.set(fromMember, 'position', fromPos);
+          _.set(toMember, 'position', toPos);
+          self.members = _.sortBy(self.members, 'position');
+          return new TucToastError(err);
+        })
+        .finally(() => {
+          self.sortableMembersOpts.disabled = false;
+        });
+    };
+
+    self.onMoveMember = function (ev, ui) {
+      const targetPosition = ui.item.attr('data-position');
+      const movedMember = self.members[targetPosition];
+      const swappedMember = self.membersBeforeDrag[targetPosition];
+
+      // check if position changed ? (not dropped at the same place)
+      if (movedMember.agentId === swappedMember.agentId) {
+        return;
+      }
+
+      self.onSwapMembers(movedMember, swappedMember);
+    };
+
+    self.startMemberEdition = function (member) {
+      self.memberInEdition = angular.copy(member);
+      self.memberInEdition.timeout = member.timeout ? member.timeout : 1;
+    };
+
+    self.cancelMemberEdition = function () {
+      self.memberInEdition = null;
+    };
+
+    self.submitMemberChanges = function () {
+      self.loaders.editing = true;
+      const attrs = ['status', 'timeout', 'wrapUpTime', 'simultaneousLines'];
+      return self.api.updateMember(self.memberInEdition).then(() => {
+        TucToast.success($translate.instant('telephony_alias_members_change_success'));
+        const toUpdate = _.find(self.members, { agentId: self.memberInEdition.agentId });
+        _.assign(toUpdate, _.pick(self.memberInEdition, attrs));
+        self.cancelMemberEdition();
+      }).catch(err => new TucToastError(err)).finally(() => {
+        self.loaders.editing = false;
+      });
+    };
+
+    self.deleteMember = function (toDelete) {
+      self.loaders.deleting = true;
+      self.api.deleteMember(self.memberToDelete).then(() => {
+        self.memberToDelete = null;
+        TucToast.success($translate.instant('telephony_alias_members_delete_success'));
+        _.remove(self.members, m => m.agentId === toDelete.agentId);
+        return self.api.reorderMembers(self.members);
+      }).then((orderedMembers) => {
+        self.members = orderedMembers;
+      }).catch(err => new TucToastError(err))
+        .finally(() => {
+          self.loaders.deleting = false;
+        });
+    };
+  },
+});

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.html
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.html
@@ -1,0 +1,191 @@
+<div class="telecom-telephony-alias-members"
+     data-ng-if="$ctrl.isInitialized">
+
+    <p class="text-center mt-5"
+       data-ng-if="$ctrl.members.length === 0"
+       data-translate="telephony_alias_members_empty"></p>
+
+    <p class="text-info mb-5"
+       data-ng-if="$ctrl.members.length >= 2">
+        <i class="ovh-font ovh-font-info line-height-normal ml-2"></i>
+        <span data-translate="telephony_alias_members_drag1"></span>
+        <i class="ovh-font ovh-font-grip"></i>
+        <span data-translate="telephony_alias_members_drag2"></span>
+    </p>
+
+    <ul class="mt-2"
+        data-ng-if="$ctrl.members.length > 0"
+        data-ui-sortable="$ctrl.sortableMembersOpts"
+        data-ng-model="$ctrl.members">
+
+        <!-- MEMBER -->
+        <li class="well"
+            data-position="{{ $index }}"
+            data-ng-repeat="member in $ctrl.members track by member.agentId">
+
+            <!-- CONTROLS -->
+            <div class="float-left">
+                <button class="btn btn-link p-0"
+                        data-ng-if="!$ctrl.memberInEdition && !$ctrl.memberToDelete"
+                        data-ng-disabled="$index === 0 || $ctrl.sortableMembersOpts.disabled"
+                        data-ng-click="$ctrl.onSwapMembers(member, $ctrl.members[$index - 1])">
+                    <i class="ovh-font ovh-font-arrow-up d-block"></i>
+                </button>
+                <i class="ovh-font ovh-font-grip cursor-move d-block my-2 text-center"
+                   data-ng-if="!$ctrl.memberInEdition && !$ctrl.memberToDelete"></i>
+                <button class="btn btn-link p-0"
+                        data-ng-if="!$ctrl.memberInEdition && !$ctrl.memberToDelete"
+                        data-ng-disabled="$index === $ctrl.members.length - 1 || $ctrl.sortableMembersOpts.disabled"
+                        data-ng-click="$ctrl.onSwapMembers(member, $ctrl.members[$index + 1])">
+                    <i class="ovh-font ovh-font-arrow-down d-block"></i>
+                </button>
+            </div>
+            <div class="float-right">
+                <button class="btn btn-link"
+                        data-ng-if="!$ctrl.memberInEdition && !$ctrl.memberToDelete"
+                        data-ng-click="$ctrl.startMemberEdition(member)">
+                    <i class="ovh-font ovh-font-editer"></i>
+                </button>
+                <button class="btn btn-link"
+                        data-ng-if="!$ctrl.memberInEdition && !$ctrl.memberToDelete"
+                        data-ng-click="$ctrl.memberToDelete = member">
+                    <i class="ovh-font ovh-font-bin"></i>
+                </button>
+            </div>
+
+            <!-- MEMBER CONTENTS -->
+            <div class="px-3"
+                 data-in-view="$ctrl.updateMemberDescription(member)"
+                 data-ng-class="{'pl-5': !$ctrl.memberInEdition && !$ctrl.memberToDelete}">
+                <strong class="member-description my-3  align-middle"
+                        data-ng-class="{'px-4': !$ctrl.memberInEdition && !$ctrl.memberToDelete}">
+                    <oui-spinner data-ng-if="member.description === undefined"
+                                 data-size="s">
+                    </oui-spinner>
+                    <span data-ng-if="member.description !== undefined"
+                          data-ng-bind="member.description || ('telephony_alias_members_number_external' | translate)"></span>
+                </strong>
+                <strong class="memberPhoneNumber px-4" data-ng-bind="member.number | tucPhoneNumber"></strong>
+                <div class="row mt-3"
+                     data-ng-if="!$ctrl.memberInEdition || $ctrl.memberInEdition.agentId !== member.agentId">
+                    <small class="col-md-3 text-nowrap text-capitalize font-weight-bold"
+                           data-ng-class="{
+                               'text-success': member.status === 'available',
+                               'text-info': member.status === 'onBreak',
+                               'text-danger': member.status === 'loggedOut'
+                           }"
+                           data-ng-bind="'telephony_alias_members_status_' + member.status | translate"></small>
+                    <small class="col-md-3 text-nowrap"
+                           data-translate="telephony_alias_members_timeout_val"
+                           data-translate-values="{ timeout: member.timeout }"></small>
+                    <small class="col-md-3 text-nowrap"
+                           data-translate="telephony_alias_members_wrap_up_time_val"
+                           data-translate-values="{ time: member.wrapUpTime }"></small>
+                    <small class="col-md-2 text-nowrap"
+                           data-translate="telephony_alias_members_simultaneous_lines_val"
+                           data-translate-values="{ count: member.simultaneousLines }"></small>
+                </div>
+
+                <!-- MEMBER EDITION -->
+                <form id="memberEditForm"
+                      name="memberEditForm"
+                      data-ng-if="$ctrl.memberInEdition.agentId === member.agentId"
+                      data-ng-submit="$ctrl.submitMemberChanges()">
+
+                    <!-- STATUS -->
+                    <div class="form-group">
+                        <label for="editStatusInput"
+                               class="control-label"
+                               data-translate="telephony_alias_members_status"></label>
+                        <select class="form-control"
+                                data-ng-model="$ctrl.memberInEdition.status">
+                            <option data-ng-repeat="opt in ['available', 'loggedOut']"
+                                    value="{{:: opt }}">
+                                <span>{{:: 'telephony_alias_members_status_' + opt | translate }}</span>
+                            </option>
+                        </select>
+                    </div>
+
+                    <!-- TIMEOUT -->
+                    <div class="form-group">
+                        <label for="editTimeoutInput"
+                               class="control-label"
+                               data-translate="telephony_alias_members_timeout"></label>
+                        <input-number-spinner id="editTimeoutInput"
+                                              class="d-inline-block text-left"
+                                              data-ng-model="$ctrl.memberInEdition.timeout"
+                                              data-input-number-spinner-min="1"
+                                              data-input-number-spinner-max="99999">
+                        </input-number-spinner>
+                    </div>
+
+                    <!-- WRAP UP TIME -->
+                    <div class="form-group">
+                        <label for="editWrapUpTimeInput"
+                               class="control-label"
+                               data-translate="telephony_alias_members_wrap_up_time"></label>
+                        <input-number-spinner id="editWrapUpTimeInput"
+                                              class="d-inline-block text-left"
+                                              data-ng-model="$ctrl.memberInEdition.wrapUpTime"
+                                              data-input-number-spinner-min="0"
+                                              data-input-number-spinner-max="99999">
+                        </input-number-spinner>
+                    </div>
+
+                    <!-- SIMULTANEOUS LINES -->
+                    <div class="form-group">
+                        <label for="editSimultaneousLinesInput"
+                               class="control-label"
+                               data-translate="telephony_alias_members_simultaneous_lines"></label>
+                        <input-number-spinner id="editSimultaneousLinesInput"
+                                              class="d-inline-block text-left"
+                                              data-ng-model="$ctrl.memberInEdition.simultaneousLines"
+                                              data-input-number-spinner-min="1"
+                                              data-input-number-spinner-max="10">
+                        </input-number-spinner>
+                    </div>
+
+                    <div class="my-3">
+                        <button type="submit"
+                                class="btn btn-primary"
+                                data-ng-disabled="$ctrl.loaders.editing">
+                            <oui-spinner class="mr-2"
+                                         data-ng-if="$ctrl.loaders.editing"
+                                         data-size="s">
+                            </oui-spinner>
+                            <span data-translate="submit"></span>
+                        </button>
+                        <button type="button"
+                                class="btn btn-default"
+                                data-ng-click="$ctrl.cancelMemberEdition()"
+                                data-ng-disabled="$ctrl.loaders.editing"
+                                data-translate="cancel">
+                        </button>
+                    </div>
+                </form>
+
+                <!-- CONFIRM DELETION -->
+                <div class="my-3"
+                     data-ng-if="$ctrl.memberToDelete === member">
+                    <button type="button"
+                            class="btn btn-danger"
+                            data-ng-click="$ctrl.deleteMember(member)"
+                            data-ng-disabled="$ctrl.loaders.deleting">
+                        <oui-spinner class="mr-2"
+                                     data-ng-if="$ctrl.loaders.deleting"
+                                     data-size="s">
+                        </oui-spinner>
+                        <span data-translate="delete"></span>
+                    </button>
+                    <button type="button"
+                            class="btn btn-default"
+                            data-ng-click="$ctrl.memberToDelete = null"
+                            data-ng-disabled="$ctrl.loaders.deleting"
+                            data-translate="cancel">
+                    </button>
+                </div>
+            </div><!-- member contents -->
+
+        </li>
+    </ul>
+</div><!-- members list -->

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.less
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.less
@@ -1,0 +1,46 @@
+.telecom-telephony-alias-members {
+  .well {
+    padding: 7px !important;
+    margin-bottom: 6px !important;
+    background-color: white;
+    border: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  }
+
+  button.no-style {
+    margin-top: -4px;
+
+    &:focus {
+      border: 1px dotted black;
+    }
+  }
+
+  .member-description {
+    width: 140px;
+    display: inline-block;
+  }
+
+  .cursor-move {
+    cursor: move;
+  }
+
+  .input-number-spinner {
+    width: 150px;
+  }
+
+  ul {
+    padding: 30px 10px;
+    list-style-type: none;
+    background-color: #efefef;
+    border-color: #ccc;
+    border-radius: @border-radius-base;
+  }
+
+  .memberPhoneNumber {
+    display: block;
+
+    @media (min-width: @screen-sm) {
+      display: inline;
+    }
+  }
+}

--- a/client/components/telecom/telephony/alias/members/translations/Messages_cs_CZ.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_cs_CZ.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Externí číslo</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Stav</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Dostupný</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Odpojený</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Číslo</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Přidat člena</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_de_DE.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_de_DE.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Externe Nummer</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Verfügbar</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Verzögerung</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Pause</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Gleichzeitige Anrufe</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Nummer</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Mitglied hinzufügen</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_ASIA.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_ASIA.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Number</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Add a member</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_AU.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_AU.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Number</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Add a member</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_CA.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_CA.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Number</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Add a member</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_GB.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_GB.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Number</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Add a member</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_SG.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_SG.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Number</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Add a member</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_US.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_US.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Offline</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Number</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Add a member</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_es_ES.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_es_ES.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">El miembro o los miembros se han añadido correctamente.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">El miembro se ha eliminado correctamente.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">El miembro se ha actualizado correctamente.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La lista no contiene ningún miembro.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">El pictograma</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">le permite arrastrarlo para reordenar la posición de sus miembros en la cola.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Número externo</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Estado</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pausa</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Desconectado</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Plazo: {{ timeout }} seg.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Descanso: {{ time }} seg.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Llamadas simult.: {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Plazo</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Descanso</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Llamadas simultáneas</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} seg.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Número</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Número en formato internacional</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Añadir otro número</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Añadir un miembro</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Añadir {{ count }} miembros</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_es_US.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_es_US.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Estado</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pausa</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Déconnecté</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Número</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Añadir un miembro</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fi_FI.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fi_FI.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Ulkoinen numero</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Tila</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Saatavilla</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Tauolla</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Kirjautunut ulos</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Samanaikaiset puhelut</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Numero</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Lisää jäsen</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fr_CA.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fr_CA.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Statut</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Déconnecté</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Numéro</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Ajouter un membre</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fr_FR.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fr_FR.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Statut</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Déconnecté</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Numéro</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Ajouter un membre</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_it_IT.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_it_IT.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membri aggiunti correttamente.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membro eliminato correttamente.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membro aggiornato correttamente.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La lista non contiene nessun membro</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Il pittogramma</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">ti permette di trascinare i membri nella fila per riordinare la loro posizione.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Numero esterno</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Stato</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Disponibile</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">In pausa</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Disconnesso</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Tempo di attesa: {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Riposo: {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Chiamate simultanee: {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Tempo di attesa</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Riposo</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Chiamate simultanee</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Numero</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numero in formato internazionale</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Aggiungi un altro numero</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Aggiungi un membro</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Aggiungi {{ count }} membri</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_lt_LT.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_lt_LT.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Nariai sėkmingai pridėti</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Narys sėkmingai ištrintas</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Narys sėkmingai atnaujintas</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">Sąraše nėra narių</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Piktograma</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">leidžia įjungti "tempk-paleisk" veiksmą narių pergrupavimui eilėje.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Išorinis numeris</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Būsena</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Galimi</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Pristabdyta</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Neprisijungęs</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Uždelsimas: {{ timeout }} sek.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Liko: {{ time }} sek.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Vienalaikiai skambučiai: {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Liko</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Perkėlimas</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Vienalaikiai skambučiai</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sek.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Numeris</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numeris tarptautiniu formatu</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Pridėti kitą numerį</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Pridėti narį</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Pridėti {{ count }} narius</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_nl_NL.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_nl_NL.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Extern nummer</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Beschikbaar</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Pauze</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Verbroken</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Nummer</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Lid toevoegen</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_pl_PL.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_pl_PL.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Numer zewnętrzny</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Dostępny</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Przerwa</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Rozłączony</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Opóźnienie</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Odpoczynek</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Jednoczesne połączenia</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Numer</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Dodaj użytkownika</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_pt_PT.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_pt_PT.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+   <translation id="telephony_alias_members_add_success" qtlid="397078">Membre(s) ajouté(s) avec succès.</translation>
+   <translation id="telephony_alias_members_delete_success" qtlid="397091">Membre supprimé avec succès.</translation>
+   <translation id="telephony_alias_members_change_success" qtlid="397104">Membre mis à jour avec succès.</translation>
+   <translation id="telephony_alias_members_empty" qtlid="397117">La liste ne contient aucun membre.</translation>
+   <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
+   <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
+   <translation id="telephony_alias_members_number_external" qtlid="93271">Número externo</translation>
+   <translation id="telephony_alias_members_status" qtlid="26443">Estado</translation>
+   <translation id="telephony_alias_members_status_available" qtlid="99920">Disponível</translation>
+   <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>
+   <translation id="telephony_alias_members_status_loggedOut" qtlid="77154">Desligado</translation>
+   <translation id="telephony_alias_members_timeout_val" qtlid="397169">Délai : {{ timeout }} sec.</translation>
+   <translation id="telephony_alias_members_wrap_up_time_val" qtlid="397182">Repos : {{ time }} sec.</translation>
+   <translation id="telephony_alias_members_simultaneous_lines_val" qtlid="397195">Appels simult. : {{ count }}</translation>
+   <translation id="telephony_alias_members_timeout" qtlid="303692">Délai</translation>
+   <translation id="telephony_alias_members_wrap_up_time" qtlid="303705">Repos</translation>
+   <translation id="telephony_alias_members_simultaneous_lines" qtlid="303718">Appels simultanés</translation>
+   <translation id="telephony_alias_members_seconds" qtlid="397208">{{ amount }} sec.</translation>
+   <translation id="telephony_alias_members_number" qtlid="30778">Número</translation>
+   <translation id="telephony_alias_members_number_placeholder" qtlid="397221">Numéro au format international</translation>
+   <translation id="telephony_alias_members_number_add" qtlid="397234">Ajouter un autre numéro</translation>
+   <translation id="telephony_alias_members_add" qtlid="392502">Adicionar um membro</translation>
+   <translation id="telephony_alias_members_add_multiple" qtlid="397247">Ajouter {{ count }} membres</translation>
+   <translation id="telephony_alias_members_explanation" qtlid="466801">Pour chaque membre, vous pouvez définir sa position, le nombre d'appels simultanés, le délai durant lequel il sonne et le délai de repos avant la présentation d'un nouvel appel suite à un appel terminé.</translation>
+   <translation id="telephony_alias_members_add_modal-warning" qtlid="480201">Votre configuration possède un ou plusieurs numéros externes. Les appels vers ces numéros vous seront facturés hors forfait quelque soit votre forfait.</translation>
+   <translation id="telephony_alias_members_add_modal-question" qtlid="480214">Continuer avec cette configuration ?</translation>
+</translations>


### PR DESCRIPTION
# Undo deletion of used component folder for ovhPabx members
MANAGER-2031

## Description of the change
Undo deletion folder by error.

For more details, see this PR (and this particular commit : https://github.com/ovh-ux/ovh-manager-telecom/pull/1098/commits/35c149b9708faf850ab61bfd75130a278807c696)

No refactor is done, and will be made once the design/feature will be revisited