### PR TITLE
fix(overthebox.order): use url instead of state

### DIFF
--- a/client/app/config/all.js
+++ b/client/app/config/all.js
@@ -344,6 +344,7 @@ angular.module('managerApp').constant('LANGUAGES', {
       hlr: 'https://www.ovhtelecom.fr/sms/home-location-register/',
     },
     fax: 'https://www.ovhtelecom.fr/fax/',
+    overTheBox: '#/overTheBox/order',
   })
   .constant('REDIRECT_URLS', {
     listTicket: 'https://www.ovh.com/manager/dedicated/index.html#/ticket',

--- a/client/components/sidebar/sidebar.config.js
+++ b/client/components/sidebar/sidebar.config.js
@@ -140,7 +140,7 @@ angular.module('managerApp').config((SidebarMenuProvider) => {
         onClick: setTracker('order-ADSL', 'navigation', 'Telecom', 'telecom'),
       }, {
         title: $translate.instant('telecom_sidebar_actions_menu_internet_otb'),
-        state: 'overTheBox-order',
+        href: ORDER_URLS.overTheBox,
       }],
     }, {
       title: $translate.instant('telecom_sidebar_actions_menu_telephony'),


### PR DESCRIPTION
OverTheBox order is now a future state.

Currently, use state resolution to redirect the user is not possible because the state can't be resolved (future state).

The fix consist to use the direct URL instead of state, waiting for a refactoring of overTheBox order section, as SMS module.