### PR TITLE
Release v10.25.1

### DIFF
--- a/client/app/common/translations/Messages_cs_CZ.xml
+++ b/client/app/common/translations/Messages_cs_CZ.xml
@@ -225,7 +225,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Mé smlouvy</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Mé objednávky</translation>
    <translation id="common_menu_contacts" qtlid="70541">Mé kontakty</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Mé tikety</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Podpora</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Besoin d'aide</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Bonjour {{username}}</translation>

--- a/client/app/common/translations/Messages_de_DE.xml
+++ b/client/app/common/translations/Messages_de_DE.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Meine Verträge</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Meine Bestellungen</translation>
    <translation id="common_menu_contacts" qtlid="70541">Meine Kontakte</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Meine Support-Anfragen</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Support</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Hilfe</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Guten Tag {{username}}</translation>

--- a/client/app/common/translations/Messages_en_ASIA.xml
+++ b/client/app/common/translations/Messages_en_ASIA.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">My contracts</translation>
    <translation id="common_menu_orders_all" qtlid="282809">My orders </translation>
    <translation id="common_menu_contacts" qtlid="70541">My contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">My support requests</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Need help?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hello {{username}}</translation>

--- a/client/app/common/translations/Messages_en_AU.xml
+++ b/client/app/common/translations/Messages_en_AU.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">My contracts</translation>
    <translation id="common_menu_orders_all" qtlid="282809">My orders </translation>
    <translation id="common_menu_contacts" qtlid="70541">My contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">My support requests</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Need help?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hello {{username}}</translation>

--- a/client/app/common/translations/Messages_en_CA.xml
+++ b/client/app/common/translations/Messages_en_CA.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">My contracts</translation>
    <translation id="common_menu_orders_all" qtlid="282809">My orders </translation>
    <translation id="common_menu_contacts" qtlid="70541">My contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">My support requests</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Need help?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hello {{username}}</translation>

--- a/client/app/common/translations/Messages_en_GB.xml
+++ b/client/app/common/translations/Messages_en_GB.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">My contracts</translation>
    <translation id="common_menu_orders_all" qtlid="282809">My orders </translation>
    <translation id="common_menu_contacts" qtlid="70541">My contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">My support requests</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Need help?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hello {{username}}</translation>

--- a/client/app/common/translations/Messages_en_SG.xml
+++ b/client/app/common/translations/Messages_en_SG.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">My contracts</translation>
    <translation id="common_menu_orders_all" qtlid="282809">My orders </translation>
    <translation id="common_menu_contacts" qtlid="70541">My contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">My support requests</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Help </translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Need help?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hello {{username}}</translation>

--- a/client/app/common/translations/Messages_en_US.xml
+++ b/client/app/common/translations/Messages_en_US.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">My contracts</translation>
    <translation id="common_menu_orders_all" qtlid="282809">My orders </translation>
    <translation id="common_menu_contacts" qtlid="70541">My contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">My support requests</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Need help?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hello {{username}}</translation>

--- a/client/app/common/translations/Messages_es_ES.xml
+++ b/client/app/common/translations/Messages_es_ES.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Mis contratos</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Mis pedidos </translation>
    <translation id="common_menu_contacts" qtlid="70541">Mis contactos</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Mis solicitudes de asistencia</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Soporte</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Ayuda</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Hola, {{username}}</translation>

--- a/client/app/common/translations/Messages_es_US.xml
+++ b/client/app/common/translations/Messages_es_US.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Mis contratos</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Mis pedidos</translation>
    <translation id="common_menu_contacts" qtlid="70541">Mis contactos</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Mis solicitudes de asistencia</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Soporte</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Besoin d'aide</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Bonjour {{username}}</translation>

--- a/client/app/common/translations/Messages_fi_FI.xml
+++ b/client/app/common/translations/Messages_fi_FI.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Sopimusehdot</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Omat tilaukset</translation>
    <translation id="common_menu_contacts" qtlid="70541">Omat kontaktit</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Katso kaikki tukipyynnöt</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Tuki</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Besoin d'aide</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Bonjour {{username}}</translation>

--- a/client/app/common/translations/Messages_fr_CA.xml
+++ b/client/app/common/translations/Messages_fr_CA.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Mes contrats</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Mes commandes</translation>
    <translation id="common_menu_contacts" qtlid="70541">Mes contacts</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Mes demandes d’assistance</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Assistance</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Besoin d'aide</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Bonjour {{username}}</translation>

--- a/client/app/common/translations/Messages_it_IT.xml
+++ b/client/app/common/translations/Messages_it_IT.xml
@@ -225,7 +225,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">I tuoi contratti </translation>
    <translation id="common_menu_orders_all" qtlid="282809">I tuoi ordini</translation>
    <translation id="common_menu_contacts" qtlid="70541">I tuoi contatti</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Tue richieste di supporto</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Supporto</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Bisogno di aiuto?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Buongiorno {{username}}</translation>

--- a/client/app/common/translations/Messages_lt_LT.xml
+++ b/client/app/common/translations/Messages_lt_LT.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Mano sutartys</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Mano užsakymai</translation>
    <translation id="common_menu_contacts" qtlid="70541">Mano kontaktai</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Mano pagalbos užklausos</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Pagalba</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Besoin d'aide</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Bonjour {{username}}</translation>

--- a/client/app/common/translations/Messages_nl_NL.xml
+++ b/client/app/common/translations/Messages_nl_NL.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Mijn contracten</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Mijn bestellingen</translation>
    <translation id="common_menu_contacts" qtlid="70541">Mijn contacten</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Mijn support-verzoeken</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Support</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Besoin d'aide</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Bonjour {{username}}</translation>

--- a/client/app/common/translations/Messages_pl_PL.xml
+++ b/client/app/common/translations/Messages_pl_PL.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Regulaminy</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Moje zamówienia</translation>
    <translation id="common_menu_contacts" qtlid="70541">Moje kontakty</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Moje zgłoszenia wysłane do pomocy technicznej</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Pomoc</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Potrzebujesz pomocy?</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Witaj {{username}}</translation>

--- a/client/app/common/translations/Messages_pt_PT.xml
+++ b/client/app/common/translations/Messages_pt_PT.xml
@@ -224,7 +224,6 @@
    <translation id="common_menu_renew_agreements" qtlid="204350">Contratos</translation>
    <translation id="common_menu_orders_all" qtlid="282809">Encomendas</translation>
    <translation id="common_menu_contacts" qtlid="70541">Contactos (utilizadores)</translation>
-   <translation id="common_menu_list_ticket" qtlid="454039">Os meus tickets</translation>
    <translation id="common_menu_support_assistance" qtlid="52699">Assistência</translation>
    <translation id="common_menu_support_assistance_expanded" qtlid="519506">Ajuda</translation>
    <translation id="common_menu_support_userAccount_1" qtlid="519519">Olá, {{username}}</translation>

--- a/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.constants.js
+++ b/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.constants.js
@@ -2,6 +2,9 @@ export const ALLOWED_FEATURE_TYPES = [
   'alias', 'line',
 ];
 
+export const NUMBER_PREFIXES = /[+]32|32|[+]33|33|[+]41|41|0032|0033|0041/;
+
 export default {
   ALLOWED_FEATURE_TYPES,
+  NUMBER_PREFIXES,
 };

--- a/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.constants.js
+++ b/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.constants.js
@@ -1,0 +1,7 @@
+export const ALLOWED_FEATURE_TYPES = [
+  'alias', 'line',
+];
+
+export default {
+  ALLOWED_FEATURE_TYPES,
+};

--- a/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.controller.js
+++ b/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.controller.js
@@ -1,3 +1,5 @@
+import { ALLOWED_FEATURE_TYPES } from './telecom-telephony-alias-configuration-agents-ovhPabx.constants';
+
 angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationAgentsOvhPabxCtrl',
   class TelecomTelephonyAliasConfigurationAgentsOvhPabxCtrl {
     constructor($q, $stateParams, $timeout, $translate, $uibModal, OvhApiTelephony,
@@ -172,10 +174,11 @@ angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationAgent
     checkExternalNumber() {
       const filteredNumbers = this.addAgentForm.numbers.filter(number => this.groupList
         .filter(telgroup => telgroup.services
-          .filter(service => service.serviceType === 'alias')
-          .filter(service => service.serviceName === number)
+          .filter(({ serviceName, serviceType }) => serviceName === number
+            && ALLOWED_FEATURE_TYPES.includes(serviceType))
           .length > 0)
         .length > 0);
+
       return filteredNumbers.length !== this.addAgentForm.numbers.length;
     }
 

--- a/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.controller.js
+++ b/client/app/telecom/telephony/alias/configuration/agents/ovhPabx/telecom-telephony-alias-configuration-agents-ovhPabx.controller.js
@@ -1,4 +1,4 @@
-import { ALLOWED_FEATURE_TYPES } from './telecom-telephony-alias-configuration-agents-ovhPabx.constants';
+import { ALLOWED_FEATURE_TYPES, NUMBER_PREFIXES } from './telecom-telephony-alias-configuration-agents-ovhPabx.constants';
 
 angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationAgentsOvhPabxCtrl',
   class TelecomTelephonyAliasConfigurationAgentsOvhPabxCtrl {
@@ -170,16 +170,24 @@ angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationAgent
       }
     }
 
+    getInternalNumber(newNumber) {
+      const allNumbers = _.flatten(
+        _.map(
+          this.groupList,
+          'services',
+        ),
+      );
+      const [, numberSuffix] = newNumber.replace(/ /g, '').split(NUMBER_PREFIXES);
+      return allNumbers.find(({ serviceName }) => _.endsWith(serviceName, numberSuffix));
+    }
+
     // Check if external numbers are defined into the list
     checkExternalNumber() {
-      const filteredNumbers = this.addAgentForm.numbers.filter(number => this.groupList
-        .filter(telgroup => telgroup.services
-          .filter(({ serviceName, serviceType }) => serviceName === number
-            && ALLOWED_FEATURE_TYPES.includes(serviceType))
-          .length > 0)
-        .length > 0);
-
-      return filteredNumbers.length !== this.addAgentForm.numbers.length;
+      return !this.addAgentForm.numbers.some((newNumber) => {
+        const internalNumber = this.getInternalNumber(newNumber);
+        return internalNumber !== undefined
+          && ALLOWED_FEATURE_TYPES.includes(internalNumber.serviceType);
+      });
     }
 
     addAgents() {

--- a/client/app/telecom/telephony/alias/configuration/feature/contactCenterSolution/sounds/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/alias/configuration/feature/contactCenterSolution/sounds/translations/Messages_fr_CA.xml
@@ -6,7 +6,7 @@
    <translation id="telephony_alias_config_contactCenterSolution_sounds_waiting_configuration" qtlid="510982">Configuration de l’attente</translation>
    <translation id="telephony_alias_config_contactCenterSolution_sounds_waiting_opening_annonce" qtlid="392879">Annonce avant mise en attente</translation>
    <translation id="telephony_alias_config_contactCenterSolution_sounds_waiting_opening_annonce_help" qtlid="510995">Annonce diffusée avant la mise en attente dans la file.</translation>
-   <translation id="telephony_alias_config_contactCenterSolution_sounds_waiting_onHold" qtlid="358422">Musique d'attente</translation>
+   <translation id="telephony_alias_config_contactCenterSolution_sounds_waiting_onHold" qtlid="358422">Musique d’attente</translation>
    <translation id="telephony_alias_config_contactCenterSolution_sounds_waiting_onHold_help" qtlid="511008">Musique diffusée lorsque l’appelant est en attente</translation>
 
    <translation id="telephony_alias_config_contactCenterSolution_sounds_overflow_configuration" qtlid="511021">Configuration du débordement</translation>

--- a/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.constants.js
+++ b/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.constants.js
@@ -1,0 +1,5 @@
+export const NUMBER_EXTERNAL_TYPE = 'external';
+
+export default {
+  NUMBER_EXTERNAL_TYPE,
+};

--- a/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.controller.js
+++ b/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.controller.js
@@ -1,3 +1,5 @@
+import { NUMBER_EXTERNAL_TYPE } from './telecom-telephony-alias-configuration-queues-ovhPabx.constants';
+
 angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationQueuesOvhPabxCtrl', function ($stateParams, $q, $translate, $timeout, $uibModal, OvhApiTelephony, TucToast, TucToastError) {
   const self = this;
 
@@ -228,24 +230,28 @@ angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationQueue
   };
 
   self.addAgentToQueue = function (queue) {
-    const modal = $uibModal.open({
-      animation: true,
-      templateUrl: 'app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx-modal.html',
-      controller: 'telecomTelephonyAliasConfigurationQueuesOvhPabxCtrlModal',
-      controllerAs: '$ctrl',
-    });
-    modal.result.then(() => {
+    let confirm = $q.when();
+    if (queue.agentToAdd.type === NUMBER_EXTERNAL_TYPE) {
+      confirm = $uibModal.open({
+        animation: true,
+        templateUrl: 'app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx-modal.html',
+        controller: 'telecomTelephonyAliasConfigurationQueuesOvhPabxCtrlModal',
+        controllerAs: '$ctrl',
+      }).result;
+    }
+
+    confirm.then(() => {
       _.set(queue, 'isAdding', true);
       return OvhApiTelephony.OvhPabx().Hunting().Agent().v6()
         .addToQueue({
           billingAccount: $stateParams.billingAccount,
           serviceName: $stateParams.serviceName,
-          agentId: queue.agentToAdd,
+          agentId: queue.agentToAdd.agentId,
         }, {
           queueId: queue.queueId,
           position: 0,
         }).$promise.then(() => {
-          const added = _.find(self.agents, { agentId: queue.agentToAdd });
+          const added = _.find(self.agents, { agentId: queue.agentToAdd.agentId });
           queue.agentsApi.addMembersToList([added]);
           _.set(queue, 'agentToAdd', null);
           _.set(queue, 'addAgent', false);

--- a/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.controller.js
+++ b/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.controller.js
@@ -1,4 +1,5 @@
 import { NUMBER_EXTERNAL_TYPE } from './telecom-telephony-alias-configuration-queues-ovhPabx.constants';
+import modalTemplate from './telecom-telephony-alias-configuration-queues-ovhPabx-modal.html';
 
 angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationQueuesOvhPabxCtrl', function ($stateParams, $q, $translate, $timeout, $uibModal, OvhApiTelephony, TucToast, TucToastError) {
   const self = this;
@@ -234,7 +235,7 @@ angular.module('managerApp').controller('TelecomTelephonyAliasConfigurationQueue
     if (queue.agentToAdd.type === NUMBER_EXTERNAL_TYPE) {
       confirm = $uibModal.open({
         animation: true,
-        templateUrl: 'app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx-modal.html',
+        template: modalTemplate,
         controller: 'telecomTelephonyAliasConfigurationQueuesOvhPabxCtrlModal',
         controllerAs: '$ctrl',
       }).result;

--- a/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.html
+++ b/client/app/telecom/telephony/alias/configuration/queues/ovhPabx/telecom-telephony-alias-configuration-queues-ovhPabx.html
@@ -229,7 +229,7 @@
                                     name="agentSelect"
                                     class="form-control"
                                     data-ng-model="queue.agentToAdd"
-                                    data-ng-options="agent.agentId as (agent.number | tucPhoneNumber) for agent in QueuesOvhPabxCtrl.getAgentsQueueToAdd(queue)"
+                                    data-ng-options="agent as (agent.number | tucPhoneNumber) for agent in QueuesOvhPabxCtrl.getAgentsQueueToAdd(queue)"
                                     required>
                             </select>
                             <button type="submit"

--- a/client/app/telecom/telephony/alias/configuration/queues/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/alias/configuration/queues/translations/Messages_fr_CA.xml
@@ -21,7 +21,7 @@
    <translation id="telephony_alias_configuration_queues_follow_call_forwards" qtlid="392749">Suivre les renvois d'appels</translation>
    <translation id="telephony_alias_configuration_queues_max_member" qtlid="294945">Nombre maximum d’appelants en attente</translation>
    <translation id="telephony_alias_configuration_queues_max_wait_time" qtlid="462095">Temps d'attente maximum dans la file (en secondes)</translation>
-   <translation id="telephony_alias_configuration_queues_sound_on_hold" qtlid="358422">Musique d'attente</translation>
+   <translation id="telephony_alias_configuration_queues_sound_on_hold" qtlid="358422">Musique d’attente</translation>
    <translation id="telephony_alias_configuration_queues_sound_on_overflow" qtlid="392866">Annonce sur débordement</translation>
    <translation id="telephony_alias_configuration_queues_sound_none" qtlid="30646">Aucun</translation>
    <translation id="telephony_alias_configuration_queues_sound_file" qtlid="392970">Fichier ...</translation>

--- a/client/app/telecom/telephony/alias/configuration/tones/oldPabx/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/alias/configuration/tones/oldPabx/translations/Messages_fr_CA.xml
@@ -12,7 +12,7 @@
    <translation id="telephony_alias_configuration_tones_old_pabx_ring_back_info" qtlid="358370"><strong>La sonnerie de pré-décroché</strong> : remplace la tonalité par défaut de pré-décroché.</translation>
    <translation id="telephony_alias_configuration_tones_old_pabx_ring_back_info_sub" qtlid="461549">La sonnerie de pré-décroché sera jouée si au moins un membre du groupe est disponible. Sinon, l'appelant est dirigé vers la musique d'attente.</translation>
 
-   <translation id="telephony_alias_configuration_tones_old_pabx_on_hold" qtlid="358422">Musique d'attente</translation>
+   <translation id="telephony_alias_configuration_tones_old_pabx_on_hold" qtlid="358422">Musique d’attente</translation>
    <translation id="telephony_alias_configuration_tones_old_pabx_on_hold_custom" qtlid="461562">Musique d'attente personnalisée</translation>
    <translation id="telephony_alias_configuration_tones_old_pabx_on_hold_info" qtlid="461575"><strong>La musique d'attente</strong> : musique diffusée lorsque l'appelant est en file d'attente.</translation>
    <translation id="telephony_alias_configuration_tones_old_pabx_on_hold_info_sub" qtlid="461588">La musique d'attente sera jouée si tous les membres du groupe sont occupés.</translation>

--- a/client/app/telecom/telephony/alias/configuration/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/alias/configuration/translations/Messages_fr_CA.xml
@@ -70,7 +70,7 @@
    <translation id="telephony_alias_config_change_type_label_svi" qtlid="511944">SVI VXML</translation>
    <translation id="telephony_alias_config_change_type_desc_svi" qtlid="511957">Le Serveur vocal interactif en VXML vous permet, via une configuration 2.1, d’utiliser un menu interactif avancé. L’appelant est invité, via des messages pré-enregistrés ou une synthèse vocale, à interagir avec le serveur grâce aux touches de son téléphone. Selon la configuration choisie, il sera possible de lire des sons ou de transférer un appel vers d’autres numéros. Notez que seuls les transferts vers les numéros OVH sont possibles.</translation>
 
-   <translation id="telephony_alias_config_change_type_label_easyHunting" qtlid="324457">File d'appels</translation>
+   <translation id="telephony_alias_config_change_type_label_easyHunting" qtlid="324457">File d’appels</translation>
    <translation id="telephony_alias_config_change_type_desc_easyHunting" qtlid="333152">Avec la file d'appels, vous pouvez gérer le flux de vos appels.<br/><br/>Jouez un son d'accueil, personnalisez votre musique d'attente et faites sonner vos collaborateurs ou différents services en fonction de stratégies que vous définissez, sur des plages horaires choisies. Vous pouvez définir le nombre maximum d'appelants dans la file d'appels et le temps d'attente maximum. Si vous ne pouvez pas répondre, votre interlocuteur sera redirigé vers le répondeur d'une ligne OVH.<br/><br/><b class="text-danger">Veuillez noter que dans ce mode de fonctionnement, les renvois d'appels des membres de votre file d'appels seront automatiquement désactivés.</b></translation>
 
    <translation id="telephony_alias_config_change_type_label_cloudHunting" qtlid="333165">File d'appels (mode expert)</translation>
@@ -81,7 +81,7 @@
    <translation id="telephony_alias_config_change_type_label_miniPabx" qtlid="333204">Mini PABX</translation>
    <translation id="telephony_alias_config_change_type_desc_miniPabx" qtlid="333217">Avec le miniPABX gérez un flux d'appels vers différents services ou collaborateurs en fonction de leur disponibilité. Vous choisissez la répartition des appels, le nombre et le temps maximum des appels dans la file d'appels.</translation>
 
-   <translation id="telephony_alias_config_change_type_label_contactCenterSolution" qtlid="324457">File d'appels</translation>
+   <translation id="telephony_alias_config_change_type_label_contactCenterSolution" qtlid="324457">File d’appels</translation>
    <translation id="telephony_alias_config_change_type_desc_contactCenterSolution" qtlid="511970">La file d’appels vous permet de rediriger un appel entrant vers plusieurs lignes, rattachées ou non à votre identifiant OVH.</translation>
 
    <translation id="telephony_alias_config_change_type_label_contactCenterSolutionExpert" qtlid="432904">Contact Center Solution</translation>

--- a/client/app/telecom/telephony/alias/special/rsva/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/alias/special/rsva/translations/Messages_fr_CA.xml
@@ -78,6 +78,6 @@
 
    <translation id="telephony_alias_special_rsva_bulk_all_success" qtlid="463148">La demande de résiliation a bien été appliquée aux services sélectionnés</translation>
    <translation id="telephony_alias_special_rsva_bulk_some_success" qtlid="463161">La demande de résiliation a bien été appliquée à {{ count}} des services sélectionnés</translation>
-   <translation id="telephony_alias_special_rsva_bulk_error" qtlid="463174">La demande de résiliation n'a pas pu être appliquée aux services suivants :</translation>
+   <translation id="telephony_alias_special_rsva_bulk_error" qtlid="463174">La demande de résiliation n’a pas pu être appliquée aux services suivants :</translation>
    <translation id="telephony_alias_special_rsva_bulk_on_error" qtlid="502081">Oups ! Une erreur est survenue lors de la demande de résiliation</translation>
 </translations>

--- a/client/app/telecom/telephony/alias/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/alias/translations/Messages_fr_CA.xml
@@ -58,11 +58,11 @@
    <translation id="telephony_alias_configuration_configuration_type_conference" qtlid="333074">Conférence</translation>
    <translation id="telephony_alias_configuration_configuration_type_cloudIvr" qtlid="333100">Serveur Vocal Interactif</translation>
    <translation id="telephony_alias_configuration_configuration_type_svi" qtlid="333126">Serveur Vocal Interactif (mode expert) en VXML</translation>
-   <translation id="telephony_alias_configuration_configuration_type_easyHunting" qtlid="324457">File d'appels</translation>
+   <translation id="telephony_alias_configuration_configuration_type_easyHunting" qtlid="324457">File d’appels</translation>
    <translation id="telephony_alias_configuration_configuration_type_cloudHunting" qtlid="333165">File d'appels (mode expert)</translation>
    <translation id="telephony_alias_configuration_configuration_type_easyPabx" qtlid="60119">Easy PABX</translation>
    <translation id="telephony_alias_configuration_configuration_type_miniPabx" qtlid="333204">Mini PABX</translation>
-   <translation id="telephony_alias_configuration_configuration_type_contactCenterSolution" qtlid="324457">File d'appels</translation>
+   <translation id="telephony_alias_configuration_configuration_type_contactCenterSolution" qtlid="324457">File d’appels</translation>
    <translation id="telephony_alias_configuration_configuration_type_contactCenterSolutionExpert" qtlid="432904">Contact Center Solution</translation>
    <translation id="telephony_alias_configuration_configuration_type_empty" qtlid="8674">Aucune</translation>
 

--- a/client/app/telecom/telephony/billingAccount/orderAlias/geographical/telecom-telephony-billing-account-orderAlias-geographical.html
+++ b/client/app/telecom/telephony/billingAccount/orderAlias/geographical/telecom-telephony-billing-account-orderAlias-geographical.html
@@ -39,13 +39,13 @@
                     </div>
                     <div class="form-group" data-ng-if="AliasOrderGeographicalCtrl.showSDASelector">
                         <!-- Order SDA redirection only -->
-                        <oui-radio data-model="AliasOrderGeographicalCtrl.offer" 
+                        <oui-radio data-model="AliasOrderGeographicalCtrl.offer"
                                    data-value="'alias'"
                                    data-on-change="AliasOrderGeographicalCtrl.changeOffer()"
                                    class="col-sm-6">
                             <span data-translate="telephony_order_geographical_order_alias"></span>
                         </oui-radio>
-                        <oui-radio data-model="AliasOrderGeographicalCtrl.offer" 
+                        <oui-radio data-model="AliasOrderGeographicalCtrl.offer"
                                    data-value="'didsOnly'"
                                    data-on-change="AliasOrderGeographicalCtrl.changeOffer()"
                                    class="col-sm-6">
@@ -67,7 +67,7 @@
                                data-ng-model="AliasOrderGeographicalCtrl.form.zone"
                                data-ng-change="AliasOrderGeographicalCtrl.changeZone()"
                                data-ng-disabled="AliasOrderGeographicalCtrl.loading.init || AliasOrderGeographicalCtrl.loading.order"
-                               data-uib-typeahead="item as item.askedCity for item in AliasOrderGeographicalCtrl.getGeographicalZone($viewValue)"
+                               data-uib-typeahead="item as item.city for item in AliasOrderGeographicalCtrl.getGeographicalZone($viewValue)"
                                data-typeahead-focus-first="true"
                                data-typeahead-editable="false"
                                data-typeahead-select-on-exact="true"

--- a/client/app/telecom/telephony/fax/management/terminate/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/fax/management/terminate/translations/Messages_fr_CA.xml
@@ -30,6 +30,6 @@
 
    <translation id="telephony_group_fax_management_terminate_bulk_all_success" qtlid="463148">La demande de résiliation a bien été appliquée aux services sélectionnés</translation>
    <translation id="telephony_group_fax_management_terminate_bulk_some_success" qtlid="463161">La demande de résiliation a bien été appliquée à {{ count}} des services sélectionnés</translation>
-   <translation id="telephony_group_fax_management_terminate_bulk_error" qtlid="463174">La demande de résiliation n'a pas pu être appliquée aux services suivants :</translation>
+   <translation id="telephony_group_fax_management_terminate_bulk_error" qtlid="463174">La demande de résiliation n’a pas pu être appliquée aux services suivants :</translation>
    <translation id="telephony_group_fax_management_terminate_bulk_on_error" qtlid="463187">Oops ! Une erreur est survenue lors de la demande de résiliation</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_en_ASIA.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_en_ASIA.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oops! An error has occurred loading the SIP domain.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oops! An error has occurred modifying the SIP domain associated with the NIC handle.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Save the changes</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modifying </translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Apply the changes</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">SIP domain of the line</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">The domain used on the line currently selected.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Saved domain</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modify the line's SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">SIP domains associated with your NIC handle</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domains used for the setup of new lines ordered with your NIC handle.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">{{ country }} domain</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modify SIP domains associated with your NIC handle</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">SIP domain modification applied to the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">SIP domain modification applied to {{ count }} of the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">SIP domain modification could not be applied to the following services:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oops! An error has occurred modifying the SIP domain.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_en_AU.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_en_AU.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oops! An error has occurred loading the SIP domain.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oops! An error has occurred modifying the SIP domain associated with the NIC handle.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Save the changes</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modifying </translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Apply the changes</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">SIP domain of the line</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">The domain used on the line currently selected.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Saved domain</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modify the line's SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">SIP domains associated with your NIC handle</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domains used for the setup of new lines ordered with your NIC handle.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">{{ country }} domain</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modify SIP domains associated with your NIC handle</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">SIP domain modification applied to the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">SIP domain modification applied to {{ count }} of the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">SIP domain modification could not be applied to the following services:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oops! An error has occurred modifying the SIP domain.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_en_CA.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_en_CA.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oops! An error has occurred loading the SIP domain.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oops! An error has occurred modifying the SIP domain associated with the NIC handle.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Save the changes</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modifying </translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Apply changes</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">SIP domain of the line</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">The domain used on the line currently selected.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Saved domain</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modify the line's SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">SIP domains associated with your NIC handle</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domains used for the setup of new lines ordered with your NIC handle.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">{{ country }} domain</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modify SIP domains associated with your NIC handle</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">SIP domain modification applied to the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">SIP domain modification applied to {{ count }} of the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">SIP domain modification could not be applied to the following services:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oops! An error has occurred modifying the SIP domain.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_en_GB.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_en_GB.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oops! An error has occurred loading the SIP domain.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oops! An error has occurred modifying the SIP domain associated with the NIC handle.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Save the changes</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modifying </translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Apply the changes</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">SIP domain of the line</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">The domain used on the line currently selected.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Saved domain</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modify the line's SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">SIP domains associated with your NIC handle</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domains used for the setup of new lines ordered with your NIC handle.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">{{ country }} domain</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modify SIP domains associated with your NIC handle</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">SIP domain modification applied to the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">SIP domain modification applied to {{ count }} of the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">SIP domain modification could not be applied to the following services:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oops! An error has occurred modifying the SIP domain.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_en_SG.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_en_SG.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oops! An error has occurred loading the SIP domain.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oops! An error has occurred modifying the SIP domain associated with the NIC handle.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Save the changes</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modifying </translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Apply the changes</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">SIP domain of the line</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">The domain used on the line currently selected.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Saved domain</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modify the line's SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">SIP domains associated with your NIC handle</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domains used for the setup of new lines ordered with your NIC handle.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">{{ country }} domain</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modify SIP domains associated with your NIC handle</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">SIP domain modification applied to the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">SIP domain modification applied to {{ count }} of the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">SIP domain modification could not be applied to the following services:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oops! An error has occurred modifying the SIP domain.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_en_US.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_en_US.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oops! An error has occurred loading the SIP domain.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oops! An error has occurred modifying the SIP domain associated with the NIC handle.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Save the changes</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modifying </translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Apply changes</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">SIP domain of the line</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">The domain used on the line currently selected.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Saved domain</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modify the line's SIP domain</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">SIP domains associated with your NIC handle</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domains used for the setup of new lines ordered with your NIC handle.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">{{ country }} domain</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modify SIP domains associated with your NIC handle</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">SIP domain modification applied to the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">SIP domain modification applied to {{ count }} of the selected services.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">SIP domain modification could not be applied to the following services:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oops! An error has occurred modifying the SIP domain.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_es_ES.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_es_ES.xml
@@ -20,8 +20,8 @@
    <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Dominio {{ country }}</translation>
    <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modificar los dominios SIP asociados a su código de cliente</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modificación del dominio SIP se ha aplicado correctamente a los servicios seleccionados.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modificación del dominio SIP se ha aplicado a {{ count }} de los servicios seleccionados.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modificación del dominio SIP no se ha podido aplicar a los siguientes servicios:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">¡Vaya! Se ha producido un error al modificar el dominio SIP.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_it_IT.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_it_IT.xml
@@ -20,8 +20,8 @@
    <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Dominio {{ country }}</translation>
    <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifica i domini SIP associati al tuo codice cliente</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modifica del dominio SIP è stata applicata correttamente ai servizi selezionati.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modifica del dominio SIP è stata applicata correttamente a {{ count }} dei servizi selezionati.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">Non è stato possibile applicare la modifica del dominio SIP a questi servizi:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Si è verificato un errore durante la modifica del dominio SIP.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/domain/translations/Messages_pt_PT.xml
+++ b/client/app/telecom/telephony/line/management/domain/translations/Messages_pt_PT.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <translations>
-   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_sip_domain_title" qtlid="338079">Domínio SIP</translation>
 
-   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Oups ! Une erreur est survenue lors du chargement du domaine SIP.</translation>
-   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Oups ! Une erreur est survenue lors de la modification du domaine SIP associé au code client.</translation>
+   <translation id="telephony_line_management_sip_domain_load_error" qtlid="387549">Lamentamos, mas ocorreu um erro ao modificar o domínio SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_client_save_error" qtlid="387562">Lamentamos, mas ocorreu um erro ao modificar o domínio SIP associado ao código de cliente.</translation>
 
    <translation id="telephony_line_management_sip_domain_save_button" qtlid="69797">Registar as modificações</translation>
    <translation id="telephony_line_management_sip_domain_save_loading" qtlid="124303">Modificação em curso</translation>
 
    <translation id="telephony_line_management_sip_domain_confirm" qtlid="249107">Aplicar alterações</translation>
 
-   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domaine SIP de la ligne</translation>
-   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domaine utilisé sur la ligne actuellement sélectionnée.</translation>
-   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domaine enregistré</translation>
-   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modifier le domaine SIP de la ligne</translation>
+   <translation id="telephony_line_management_sip_domain_line_title" qtlid="387575">Domínio SIP da linha</translation>
+   <translation id="telephony_line_management_sip_domain_line_info" qtlid="387588">Domínio utilizado na linha selecionada atualmente.</translation>
+   <translation id="telephony_line_management_sip_domain_line_registered" qtlid="307904">Domínio registado</translation>
+   <translation id="telephony_line_management_sip_domain_line_edit_button" qtlid="387601">Modificar o domínio SIP da linha</translation>
 
-   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domaines SIP associés à votre code client</translation>
-   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domaines utilisés lors de l'installation de nouvelles lignes commandées avec votre code client.</translation>
-   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domaine {{ country }}</translation>
-   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modifier les domaines SIP associés à votre code client</translation>
+   <translation id="telephony_line_management_sip_domain_client_title" qtlid="387614">Domínios SIP associados ao seu código de cliente</translation>
+   <translation id="telephony_line_management_sip_domain_client_info" qtlid="387627">Domínios utilizados durante a instalação de novas linhas encomendadas com o seu código de cliente.</translation>
+   <translation id="telephony_line_management_sip_domain_client_country" qtlid="387640">Domínio {{ country }}</translation>
+   <translation id="telephony_line_management_sip_domain_client_edit_button" qtlid="387653">Modificar os domínios SIP associados ao seu código de cliente</translation>
 
-   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">La modification du domaine SIP a bien été appliquée aux services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">La modification du domaine SIP a bien été appliquée à {{ count }} des services sélectionnés.</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">La modification du domaine SIP n'a pu être appliquée au(x) service(s) suivant(s) :</translation>
-   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Oups ! Une erreur est survenue lors de la modification du domaine SIP.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_all_success" qtlid="458312">A alteração do domínio SIP foi corretamente aplicada aos serviços selecionados.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_some_success" qtlid="458325">A alteração do domínio SIP foi aplicada a {{ count }} dos serviços selecionados.</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_error" qtlid="458338">Não foi possível aplicar a alteração do domínio SIP aos seguintes serviços:</translation>
+   <translation id="telephony_line_management_sip_domain_bulk_on_error" qtlid="458351">Lamentamos, mas ocorreu um erro ao modificar o domínio SIP.</translation>
 </translations>

--- a/client/app/telecom/telephony/line/management/translations/Messages_en_ASIA.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_en_ASIA.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">General information</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">SIP domain</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Upgrade</translation>

--- a/client/app/telecom/telephony/line/management/translations/Messages_en_AU.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_en_AU.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">General information</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">SIP domain</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Upgrade</translation>

--- a/client/app/telecom/telephony/line/management/translations/Messages_en_CA.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_en_CA.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">General information</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">SIP domain</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Upgrade</translation>

--- a/client/app/telecom/telephony/line/management/translations/Messages_en_GB.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_en_GB.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">General information</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">SIP domain</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Upgrade</translation>

--- a/client/app/telecom/telephony/line/management/translations/Messages_en_SG.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_en_SG.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">General information</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">SIP domain</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Upgrade</translation>

--- a/client/app/telecom/telephony/line/management/translations/Messages_en_US.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_en_US.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">General information</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">SIP domain</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Upgrade</translation>

--- a/client/app/telecom/telephony/line/management/translations/Messages_pt_PT.xml
+++ b/client/app/telecom/telephony/line/management/translations/Messages_pt_PT.xml
@@ -4,7 +4,7 @@
 
    <translation id="telephony_line_management_actions_line_details_offer" qtlid="27115">Informações gerais</translation>
    <translation id="telephony_line_management_actions_line_sip_password" qtlid="338066">Mot de passe SIP</translation>
-   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domaine SIP</translation>
+   <translation id="telephony_line_management_actions_line_sip_domain_management" qtlid="338079">Domínio SIP</translation>
    <translation id="telephony_line_management_actions_line_sip_ips_restrictions" qtlid="338092">Restrictions SIP par IP</translation>
    <translation id="telephony_line_management_actions_line_language" qtlid="338105">Gérer la langue</translation>
    <translation id="telephony_line_management_actions_line_resume_offer" qtlid="25783">Mudar de oferta</translation>

--- a/client/app/telecom/telephony/line/phone/accessories/choice/telecom-telephony-line-phone-accessories-choice.html
+++ b/client/app/telecom/telephony/line/phone/accessories/choice/telecom-telephony-line-phone-accessories-choice.html
@@ -56,11 +56,12 @@
                                <span data-ng-bind-html="accessory.price.text | tucFormatPrice:{ withoutTax : false }"></span>
                                <span data-translate="common_without_tax"></span>
                             </p>
-                            <input-number-spinner data-ng-model="accessory.quantity"
-                                                  data-input-number-spinner-min="AccessoriesChoiceCtrl.spinnerExtremities.min"
-                                                  data-input-number-spinner-max="AccessoriesChoiceCtrl.spinnerExtremities.max"
-                                                  data-input-number-spinner-on-change="AccessoriesChoiceCtrl.updateOrderTotal()">
-                            </input-number-spinner>
+                            <oui-numeric class="mx-auto"
+                                         data-model="accessory.quantity"
+                                         data-min="::AccessoriesChoiceCtrl.spinnerExtremities.min"
+                                         data-max="::AccessoriesChoiceCtrl.spinnerExtremities.max"
+                                         data-on-change="AccessoriesChoiceCtrl.updateOrderTotal()">
+                            </oui-numeric>
                         </div>
                     </div>
                 </div>

--- a/client/app/telecom/telephony/line/tones/translations/Messages_fr_CA.xml
+++ b/client/app/telecom/telephony/line/tones/translations/Messages_fr_CA.xml
@@ -6,7 +6,7 @@
    <translation id="telephony_line_tones_info3" qtlid="358383"><strong>La musique d'attente</strong> : musique diffusée lorsque l'appelant est en attente. La musique d'attente sera diffusée si vous mettez en attente un interlocuteur lors d'une conversation téléphonique.</translation>
    <translation id="telephony_line_tones_info4" qtlid="358396"><strong>L'annonce sur ligne occupée</strong> : annonce diffusée lorsque la ligne est occupée. L'annonce sera diffusée lors d'un appel direct (sans passer par un easyPabx ou un miniPabx au préalable), aucune mise en relation avec l'appelé ne sera établie.</translation>
    <translation id="telephony_line_tones_ringback" qtlid="358409">Sonnerie de pré-décroché</translation>
-   <translation id="telephony_line_tones_onhold" qtlid="358422">Musique d'attente</translation>
+   <translation id="telephony_line_tones_onhold" qtlid="358422">Musique d’attente</translation>
    <translation id="telephony_line_tones_callwaiting" qtlid="358435">Annonce sur ligne occupée</translation>
    <translation id="telephony_line_tones_type_custom_sound" qtlid="358448">Personnalisée</translation>
    <translation id="telephony_line_tones_type_none" qtlid="101193">Par défaut</translation>

--- a/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.html
+++ b/client/components/telecom/telephony/alias/members/telecom-telephony-alias-members.html
@@ -63,7 +63,7 @@
                                  data-size="s">
                     </oui-spinner>
                     <span data-ng-if="member.description !== undefined"
-                          data-ng-bind="member.description || ('telephony_alias_members_number_external' | translate)"></span>
+                          data-ng-bind="member.description || ('telephony_alias_members_number_' + member.type | translate)"></span>
                 </strong>
                 <strong class="memberPhoneNumber px-4" data-ng-bind="member.number | tucPhoneNumber"></strong>
                 <div class="row mt-3"

--- a/client/components/telecom/telephony/alias/members/translations/Messages_cs_CZ.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_cs_CZ.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Externí číslo</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Stav</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Dostupný</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_de_DE.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_de_DE.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Externe Nummer</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Verfügbar</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_ASIA.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_ASIA.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_AU.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_AU.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_CA.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_CA.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_GB.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_GB.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_SG.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_SG.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_en_US.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_en_US.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">External number</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Available</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Break</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_es_ES.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_es_ES.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">El pictograma</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">le permite arrastrarlo para reordenar la posición de sus miembros en la cola.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Número externo</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Estado</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pausa</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_es_US.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_es_US.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Estado</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pausa</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fi_FI.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fi_FI.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Ulkoinen numero</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Tila</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Saatavilla</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Tauolla</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fr_CA.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fr_CA.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Statut</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fr_FR.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fr_FR.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Statut</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_fr_FR.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_fr_FR.xml
@@ -7,7 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Numéro externe</translation>
-   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
+   <translation id="telephony_alias_members_number_internal" qtlid="523281">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Statut</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponible</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_it_IT.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_it_IT.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Il pittogramma</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">ti permette di trascinare i membri nella fila per riordinare la loro posizione.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Numero esterno</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Stato</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponibile</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">In pausa</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_lt_LT.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_lt_LT.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Piktograma</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">leidžia įjungti "tempk-paleisk" veiksmą narių pergrupavimui eilėje.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Išorinis numeris</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Būsena</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Galimi</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Pristabdyta</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_nl_NL.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_nl_NL.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Extern nummer</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Beschikbaar</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Pauze</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_pl_PL.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_pl_PL.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Numer zewnętrzny</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Status</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Dostępny</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">Przerwa</translation>

--- a/client/components/telecom/telephony/alias/members/translations/Messages_pt_PT.xml
+++ b/client/components/telecom/telephony/alias/members/translations/Messages_pt_PT.xml
@@ -7,6 +7,7 @@
    <translation id="telephony_alias_members_drag1" qtlid="397130">Le pictogramme</translation>
    <translation id="telephony_alias_members_drag2" qtlid="397143">vous permet d'effectuer un glisser-déposer afin de réordonner la position de vos membres dans la file.</translation>
    <translation id="telephony_alias_members_number_external" qtlid="93271">Número externo</translation>
+   <translation id="telephony_alias_members_number_internal">Numéro interne</translation>
    <translation id="telephony_alias_members_status" qtlid="26443">Estado</translation>
    <translation id="telephony_alias_members_status_available" qtlid="99920">Disponível</translation>
    <translation id="telephony_alias_members_status_onBreak" qtlid="397156">En pause</translation>


### PR DESCRIPTION
# :package: Release v10.25.1

### :bug: Bug Fix

MANAGER-1271 - fix(telephony.add.line): prevent disclaimer if no external number added (#1374)
MANAGER-2592 - fix(telephony.alias.ccs.queues): set correct type of queue member (#1376)
UXCT-126 - fix(line.phone.accessories): replace input number by oui numeric (#1375)
UXCT-117 - fix(telephony.order): fix property alias to display found options (#1371)